### PR TITLE
Harden ingestion and decouple sidra_va

### DIFF
--- a/src/sidra_database/diagnostics.py
+++ b/src/sidra_database/diagnostics.py
@@ -1,0 +1,228 @@
+"""Diagnostics and repair helpers for SIDRA metadata ingestion."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from .api_client import SidraApiClient
+from .db import sqlite_session
+from .ingest import ingest_agregado
+
+
+def _fetch_scalar(conn, query: str, params: Sequence[Any] | None = None) -> int:
+    cursor = conn.execute(query, params or ())
+    row = cursor.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def _get_index_presence(conn, table: str, expected: Iterable[str]) -> dict[str, bool]:
+    cursor = conn.execute(f"PRAGMA index_list({table})")
+    available = {row[1] for row in cursor.fetchall()}
+    return {name: name in available for name in expected}
+
+
+def collect_missing_variable_ids(conn, *, limit: int | None = None) -> list[int]:
+    query = (
+        "SELECT a.id FROM agregados AS a "
+        "LEFT JOIN (SELECT DISTINCT agregado_id FROM variables) AS v ON v.agregado_id = a.id "
+        "WHERE v.agregado_id IS NULL ORDER BY a.id"
+    )
+    if limit is not None:
+        query += f" LIMIT {int(limit)}"
+    cursor = conn.execute(query)
+    return [int(row[0]) for row in cursor.fetchall()]
+
+
+def global_health_report(conn, *, sample_limit: int = 50) -> dict[str, Any]:
+    total_agregados = _fetch_scalar(conn, "SELECT COUNT(*) FROM agregados")
+    agregados_with_variables = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM variables"
+    )
+    agregados_with_classifications = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM classifications"
+    )
+    agregados_with_categories = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM categories"
+    )
+
+    missing_ids = collect_missing_variable_ids(conn)
+    sample_missing = missing_ids[:sample_limit]
+
+    index_status = {
+        "variables": _get_index_presence(conn, "variables", ["idx_variables_agregado"]),
+        "categories": _get_index_presence(conn, "categories", ["idx_categories_agregado"]),
+        "localities": _get_index_presence(conn, "localities", ["idx_localities_agregado"]),
+        "embeddings": _get_index_presence(conn, "embeddings", ["idx_embeddings_agregado"]),
+    }
+
+    journal_row = conn.execute("PRAGMA journal_mode").fetchone()
+    journal_mode = str(journal_row[0]).upper() if journal_row else "UNKNOWN"
+
+    return {
+        "counts": {
+            "agregados": total_agregados,
+            "agregados_with_variables": agregados_with_variables,
+            "agregados_with_classifications": agregados_with_classifications,
+            "agregados_with_categories": agregados_with_categories,
+            "agregados_missing_variables": len(missing_ids),
+        },
+        "sample_missing_variables": sample_missing,
+        "indexes": index_status,
+        "journal_mode": journal_mode,
+    }
+
+
+async def api_vs_db_spot_check(
+    conn,
+    *,
+    sample_size: int = 10,
+    client: SidraApiClient | None = None,
+) -> dict[str, Any]:
+    missing_ids = collect_missing_variable_ids(conn, limit=sample_size)
+    if not missing_ids:
+        return {
+            "sampled": 0,
+            "api_nonempty": 0,
+            "api_empty": 0,
+            "errors": 0,
+            "details": [],
+        }
+
+    own_client = False
+    if client is None:
+        client = SidraApiClient()
+        own_client = True
+
+    results: list[dict[str, Any]] = []
+    try:
+        for agregado_id in missing_ids:
+            try:
+                metadata = await client.fetch_metadata(agregado_id)
+                variaveis = metadata.get("variaveis") if isinstance(metadata, dict) else None
+                if isinstance(variaveis, list):
+                    count = len(variaveis)
+                else:
+                    count = 0
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": count,
+                        "error": None,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": None,
+                        "error": str(exc)[:200],
+                    }
+                )
+    finally:
+        if own_client:
+            await client.close()
+
+    api_nonempty = sum(1 for item in results if (item["variables_in_api"] or 0) > 0)
+    api_empty = sum(1 for item in results if item["variables_in_api"] == 0)
+    errors = sum(1 for item in results if item["error"])
+
+    return {
+        "sampled": len(results),
+        "api_nonempty": api_nonempty,
+        "api_empty": api_empty,
+        "errors": errors,
+        "details": results,
+    }
+
+
+@dataclass
+class RepairResult:
+    attempted: int
+    succeeded: int
+    failed: int
+    failures: list[tuple[int, str]]
+
+
+async def _ingest_chunk(
+    ids: Sequence[int],
+    *,
+    concurrency: int,
+    client: SidraApiClient,
+) -> list[tuple[int, bool, str | None]]:
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+    results: list[tuple[int, bool, str | None]] = []
+
+    async def worker(agregado_id: int) -> None:
+        async with semaphore:
+            try:
+                await ingest_agregado(
+                    agregado_id,
+                    client=client,
+                    generate_embeddings=False,
+                )
+                results.append((agregado_id, True, None))
+            except Exception as exc:  # noqa: BLE001
+                results.append((agregado_id, False, str(exc)[:200]))
+
+    await asyncio.gather(*(worker(ag_id) for ag_id in ids))
+    return results
+
+
+async def repair_missing_variables(
+    *,
+    chunk_size: int = 50,
+    concurrency: int = 6,
+    limit: int | None = None,
+    max_retries: int = 3,
+) -> RepairResult:
+    with sqlite_session() as conn:
+        missing_ids = collect_missing_variable_ids(conn, limit=limit)
+
+    if not missing_ids:
+        return RepairResult(attempted=0, succeeded=0, failed=0, failures=[])
+
+    attempted = len(missing_ids)
+    succeeded = 0
+    failures: list[tuple[int, str]] = []
+
+    async with SidraApiClient() as client:
+        for start in range(0, len(missing_ids), max(1, chunk_size)):
+            chunk = missing_ids[start : start + max(1, chunk_size)]
+            remaining = list(chunk)
+            attempt = 0
+            partial_failures: list[tuple[int, str]] = []
+            while remaining and attempt < max(1, max_retries):
+                attempt += 1
+                results = await _ingest_chunk(
+                    remaining,
+                    concurrency=concurrency,
+                    client=client,
+                )
+                remaining = [ag_id for ag_id, ok, _ in results if not ok]
+                succeeded += sum(1 for _, ok, _ in results if ok)
+                partial_failures = [
+                    (ag_id, error or "unknown error")
+                    for ag_id, ok, error in results
+                    if not ok
+                ]
+
+            failures.extend(partial_failures)
+
+    failed = len(failures)
+    return RepairResult(
+        attempted=attempted,
+        succeeded=succeeded,
+        failed=failed,
+        failures=failures,
+    )
+
+
+__all__ = [
+    "RepairResult",
+    "api_vs_db_spot_check",
+    "collect_missing_variable_ids",
+    "global_health_report",
+    "repair_missing_variables",
+]
+

--- a/src/sidra_va/config.py
+++ b/src/sidra_va/config.py
@@ -1,0 +1,61 @@
+"""Configuration helpers for the sidra_va package."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(frozen=True)
+class VaSettings:
+    """Runtime configuration for sidra_va components."""
+
+    embedding_api_url: str = "http://127.0.0.1:1234/v1/embeddings"
+    embedding_model: str = "text-embedding-qwen3-embedding-0.6b@f16"
+    request_timeout: float = 30.0
+    user_agent: str = "sidra-va/0.1"
+    database_timeout: float = 60.0
+
+
+def _lookup_env(name: str) -> str | None:
+    candidates = {name, name.upper(), name.lower()}
+    for candidate in candidates:
+        if candidate in os.environ:
+            return os.environ[candidate]
+    return None
+
+
+def _load_settings() -> VaSettings:
+    defaults = VaSettings()
+    prefix = "SIDRA_VA_"
+    overrides: dict[str, object] = {}
+    for field in ("embedding_api_url", "embedding_model", "user_agent"):
+        value = _lookup_env(f"{prefix}{field.upper()}")
+        if value:
+            overrides[field] = value
+    timeout_raw = _lookup_env(f"{prefix}REQUEST_TIMEOUT")
+    if timeout_raw:
+        try:
+            overrides["request_timeout"] = float(timeout_raw)
+        except ValueError:
+            pass
+    db_timeout_raw = _lookup_env(f"{prefix}DATABASE_TIMEOUT")
+    if db_timeout_raw:
+        try:
+            overrides["database_timeout"] = float(db_timeout_raw)
+        except ValueError:
+            pass
+    if overrides:
+        return VaSettings(**{**defaults.__dict__, **overrides})
+    return defaults
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> VaSettings:
+    """Return cached VA configuration settings."""
+
+    return _load_settings()
+
+
+__all__ = ["VaSettings", "get_settings"]
+

--- a/src/sidra_va/db.py
+++ b/src/sidra_va/db.py
@@ -1,0 +1,93 @@
+"""SQLite helpers for sidra_va operations."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from .config import get_settings
+
+
+def _has_base_tables(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        conn = sqlite3.connect(path)
+    except sqlite3.Error:
+        return False
+    try:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('agregados', 'variables')"
+        )
+        names = {row[0] for row in cursor.fetchall()}
+        return "agregados" in names and "variables" in names
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+def _resolve_database_path(env_value: str | None) -> Path:
+    candidate = Path(env_value).expanduser().resolve() if env_value else None
+    default_path = Path("sidra.db").expanduser().resolve()
+    if candidate is not None:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        if not candidate.exists():
+            if _has_base_tables(default_path):
+                return default_path
+            return candidate
+        if _has_base_tables(candidate):
+            return candidate
+        if _has_base_tables(default_path):
+            return default_path
+        return candidate
+    default_path.parent.mkdir(parents=True, exist_ok=True)
+    return default_path
+
+
+_LAST_ENV_VALUE: str | None = None
+_DATABASE_PATH: Path | None = None
+
+
+def get_database_path() -> Path:
+    """Resolve the SQLite database path used for VA operations."""
+
+    global _DATABASE_PATH, _LAST_ENV_VALUE
+    env_value = os.getenv("SIDRA_DATABASE_PATH")
+    if _DATABASE_PATH is None or env_value != _LAST_ENV_VALUE:
+        _DATABASE_PATH = _resolve_database_path(env_value)
+        _LAST_ENV_VALUE = env_value
+    return _DATABASE_PATH
+
+
+def create_connection() -> sqlite3.Connection:
+    """Create a SQLite connection configured for concurrent reads/writes."""
+
+    settings = get_settings()
+    timeout = max(float(settings.database_timeout), 30.0)
+    connection = sqlite3.connect(
+        get_database_path(),
+        timeout=timeout,
+        check_same_thread=False,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=NORMAL")
+    busy_timeout_ms = max(int(timeout * 1000), 60000)
+    connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+    return connection
+
+
+@contextmanager
+def sqlite_session() -> Iterator[sqlite3.Connection]:
+    connection = create_connection()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+__all__ = ["create_connection", "get_database_path", "sqlite_session"]
+

--- a/src/sidra_va/embed.py
+++ b/src/sidra_va/embed.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 from array import array
 
-from sidra_database.db import create_connection, ensure_schema
-from sidra_database.embedding import EmbeddingClient
-
+from .db import create_connection
+from .embedding_client import EmbeddingClient
 from .schema_migrations import apply_va_schema
 from .utils import run_with_retries, sha256_text, utcnow_iso
 
@@ -28,7 +27,6 @@ async def embed_vas_for_agregados(
     def _collect_targets():
         conn = create_connection()
         try:
-            ensure_schema(conn)
             apply_va_schema(conn)
             if agregado_ids is None:
                 cursor = conn.execute("SELECT va_id, agregado_id, text FROM value_atoms")
@@ -57,7 +55,6 @@ async def embed_vas_for_agregados(
         def _should_embed() -> bool:
             conn = create_connection()
             try:
-                ensure_schema(conn)
                 apply_va_schema(conn)
                 row = conn.execute(
                     "SELECT text_hash FROM embeddings WHERE entity_type = 'va' AND entity_id = ? AND model = ?",
@@ -81,37 +78,37 @@ async def embed_vas_for_agregados(
                 stats["failed"] += 1
                 return
 
-            def _persist() -> None:
+        def _persist() -> None:
+            conn = create_connection()
+            try:
+                apply_va_schema(conn)
+
                 def _write() -> None:
-                    conn = create_connection()
-                    try:
-                        ensure_schema(conn)
-                        apply_va_schema(conn)
-                        with conn:
-                            conn.execute(
-                                """
-                                INSERT OR REPLACE INTO embeddings (
-                                    entity_type, entity_id, agregado_id, text_hash, model, dimension, vector, created_at
-                                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                                """,
-                                (
-                                    "va",
-                                    va_id,
-                                    agregado_id,
-                                    text_hash,
-                                    model_name,
-                                    len(vector),
-                                    _vector_to_blob(vector),
-                                    utcnow_iso(),
-                                ),
-                            )
-                    finally:
-                        conn.close()
+                    with conn:
+                        conn.execute(
+                            """
+                            INSERT OR REPLACE INTO embeddings (
+                                entity_type, entity_id, agregado_id, text_hash, model, dimension, vector, created_at
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                "va",
+                                va_id,
+                                agregado_id,
+                                text_hash,
+                                model_name,
+                                len(vector),
+                                _vector_to_blob(vector),
+                                utcnow_iso(),
+                            ),
+                        )
 
                 run_with_retries(_write)
+            finally:
+                conn.close()
 
-            await asyncio.to_thread(_persist)
-            stats["embedded"] += 1
+        await asyncio.to_thread(_persist)
+        stats["embedded"] += 1
 
     await asyncio.gather(*[_process(target) for target in targets])
     return stats

--- a/src/sidra_va/embedding_client.py
+++ b/src/sidra_va/embedding_client.py
@@ -1,0 +1,64 @@
+"""Embedding client used exclusively within sidra_va."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import httpx
+import orjson
+
+from .config import get_settings
+
+
+class EmbeddingClient:
+    """Synchronous HTTP client for embedding generation."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._base_url = base_url or settings.embedding_api_url
+        self._model = model or settings.embedding_model
+        self._timeout = timeout or settings.request_timeout
+        self._headers = {"Content-Type": "application/json", "User-Agent": settings.user_agent}
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def embed_text(self, text: str, *, model: str | None = None) -> Sequence[float]:
+        payload = {
+            "model": model or self._model,
+            "input": text,
+        }
+        response = httpx.post(
+            self._base_url,
+            content=orjson.dumps(payload),
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["data"][0]["embedding"]
+
+    def embed_batch(self, texts: Iterable[str], *, model: str | None = None) -> list[Sequence[float]]:
+        payload = {
+            "model": model or self._model,
+            "input": list(texts),
+        }
+        response = httpx.post(
+            self._base_url,
+            content=orjson.dumps(payload),
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [item["embedding"] for item in data["data"]]
+
+
+__all__ = ["EmbeddingClient"]
+

--- a/src/sidra_va/neighbors.py
+++ b/src/sidra_va/neighbors.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import json
-from typing import List, Mapping
+from typing import Mapping
 
-from sidra_database.db import create_connection, ensure_schema
-
+from .db import create_connection
 from .schema_migrations import apply_va_schema
 from .search_va import VaResult
-from .synonyms import load_synonyms_into_memory, normalize_basic
+from .synonyms import normalize_basic
 
 
 def _levels(row) -> set[str]:
@@ -89,7 +87,6 @@ def find_neighbors_for_va(
 ) -> list[tuple[VaResult, float]]:
     conn = create_connection()
     try:
-        ensure_schema(conn)
         apply_va_schema(conn)
         cursor = conn.execute(
             """

--- a/src/sidra_va/search_va.py
+++ b/src/sidra_va/search_va.py
@@ -7,9 +7,8 @@ from array import array
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Mapping, Sequence
 
-from sidra_database.db import create_connection, ensure_schema
-from sidra_database.embedding import EmbeddingClient
-
+from .db import create_connection
+from .embedding_client import EmbeddingClient
 from .schema_migrations import apply_va_schema
 from .scoring import DEFAULT_WEIGHTS, StructureMatch, rrf
 from .synonyms import SynonymMap, load_synonyms_into_memory, normalize_basic
@@ -88,7 +87,6 @@ async def search_value_atoms(
 
     conn = create_connection()
     try:
-        ensure_schema(conn)
         apply_va_schema(conn)
         synonyms = load_synonyms_into_memory(conn)
 


### PR DESCRIPTION
## Summary
- Harden ingestion by validating metadata payloads before writes, preserving existing child rows when the API returns empty collections, and logging ingestion failures without partial deletes
- Add diagnostics and repair helpers to inspect missing variables, compare API data, and reingest tables through new CLI commands
- Decouple sidra_va from sidra_database by introducing local config/db/embedding helpers, enforcing base-table readiness checks, improving VA build/embedding write patterns, and lowering default concurrency

## Testing
- pytest tests/test_va_neighbors.py::test_find_neighbors_matches_by_fingerprint

------
https://chatgpt.com/codex/tasks/task_e_68e088c67454832aa7797fca2a4bb7ad