### PR TITLE
Harden sidra_va config and search semantics

### DIFF
--- a/src/sidra_database/diagnostics.py
+++ b/src/sidra_database/diagnostics.py
@@ -1,0 +1,228 @@
+"""Diagnostics and repair helpers for SIDRA metadata ingestion."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from .api_client import SidraApiClient
+from .db import sqlite_session
+from .ingest import ingest_agregado
+
+
+def _fetch_scalar(conn, query: str, params: Sequence[Any] | None = None) -> int:
+    cursor = conn.execute(query, params or ())
+    row = cursor.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def _get_index_presence(conn, table: str, expected: Iterable[str]) -> dict[str, bool]:
+    cursor = conn.execute(f"PRAGMA index_list({table})")
+    available = {row[1] for row in cursor.fetchall()}
+    return {name: name in available for name in expected}
+
+
+def collect_missing_variable_ids(conn, *, limit: int | None = None) -> list[int]:
+    query = (
+        "SELECT a.id FROM agregados AS a "
+        "LEFT JOIN (SELECT DISTINCT agregado_id FROM variables) AS v ON v.agregado_id = a.id "
+        "WHERE v.agregado_id IS NULL ORDER BY a.id"
+    )
+    if limit is not None:
+        query += f" LIMIT {int(limit)}"
+    cursor = conn.execute(query)
+    return [int(row[0]) for row in cursor.fetchall()]
+
+
+def global_health_report(conn, *, sample_limit: int = 50) -> dict[str, Any]:
+    total_agregados = _fetch_scalar(conn, "SELECT COUNT(*) FROM agregados")
+    agregados_with_variables = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM variables"
+    )
+    agregados_with_classifications = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM classifications"
+    )
+    agregados_with_categories = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM categories"
+    )
+
+    missing_ids = collect_missing_variable_ids(conn)
+    sample_missing = missing_ids[:sample_limit]
+
+    index_status = {
+        "variables": _get_index_presence(conn, "variables", ["idx_variables_agregado"]),
+        "categories": _get_index_presence(conn, "categories", ["idx_categories_agregado"]),
+        "localities": _get_index_presence(conn, "localities", ["idx_localities_agregado"]),
+        "embeddings": _get_index_presence(conn, "embeddings", ["idx_embeddings_agregado"]),
+    }
+
+    journal_row = conn.execute("PRAGMA journal_mode").fetchone()
+    journal_mode = str(journal_row[0]).upper() if journal_row else "UNKNOWN"
+
+    return {
+        "counts": {
+            "agregados": total_agregados,
+            "agregados_with_variables": agregados_with_variables,
+            "agregados_with_classifications": agregados_with_classifications,
+            "agregados_with_categories": agregados_with_categories,
+            "agregados_missing_variables": len(missing_ids),
+        },
+        "sample_missing_variables": sample_missing,
+        "indexes": index_status,
+        "journal_mode": journal_mode,
+    }
+
+
+async def api_vs_db_spot_check(
+    conn,
+    *,
+    sample_size: int = 10,
+    client: SidraApiClient | None = None,
+) -> dict[str, Any]:
+    missing_ids = collect_missing_variable_ids(conn, limit=sample_size)
+    if not missing_ids:
+        return {
+            "sampled": 0,
+            "api_nonempty": 0,
+            "api_empty": 0,
+            "errors": 0,
+            "details": [],
+        }
+
+    own_client = False
+    if client is None:
+        client = SidraApiClient()
+        own_client = True
+
+    results: list[dict[str, Any]] = []
+    try:
+        for agregado_id in missing_ids:
+            try:
+                metadata = await client.fetch_metadata(agregado_id)
+                variaveis = metadata.get("variaveis") if isinstance(metadata, dict) else None
+                if isinstance(variaveis, list):
+                    count = len(variaveis)
+                else:
+                    count = 0
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": count,
+                        "error": None,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": None,
+                        "error": str(exc)[:200],
+                    }
+                )
+    finally:
+        if own_client:
+            await client.close()
+
+    api_nonempty = sum(1 for item in results if (item["variables_in_api"] or 0) > 0)
+    api_empty = sum(1 for item in results if item["variables_in_api"] == 0)
+    errors = sum(1 for item in results if item["error"])
+
+    return {
+        "sampled": len(results),
+        "api_nonempty": api_nonempty,
+        "api_empty": api_empty,
+        "errors": errors,
+        "details": results,
+    }
+
+
+@dataclass
+class RepairResult:
+    attempted: int
+    succeeded: int
+    failed: int
+    failures: list[tuple[int, str]]
+
+
+async def _ingest_chunk(
+    ids: Sequence[int],
+    *,
+    concurrency: int,
+    client: SidraApiClient,
+) -> list[tuple[int, bool, str | None]]:
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+    results: list[tuple[int, bool, str | None]] = []
+
+    async def worker(agregado_id: int) -> None:
+        async with semaphore:
+            try:
+                await ingest_agregado(
+                    agregado_id,
+                    client=client,
+                    generate_embeddings=False,
+                )
+                results.append((agregado_id, True, None))
+            except Exception as exc:  # noqa: BLE001
+                results.append((agregado_id, False, str(exc)[:200]))
+
+    await asyncio.gather(*(worker(ag_id) for ag_id in ids))
+    return results
+
+
+async def repair_missing_variables(
+    *,
+    chunk_size: int = 50,
+    concurrency: int = 6,
+    limit: int | None = None,
+    max_retries: int = 3,
+) -> RepairResult:
+    with sqlite_session() as conn:
+        missing_ids = collect_missing_variable_ids(conn, limit=limit)
+
+    if not missing_ids:
+        return RepairResult(attempted=0, succeeded=0, failed=0, failures=[])
+
+    attempted = len(missing_ids)
+    succeeded = 0
+    failures: list[tuple[int, str]] = []
+
+    async with SidraApiClient() as client:
+        for start in range(0, len(missing_ids), max(1, chunk_size)):
+            chunk = missing_ids[start : start + max(1, chunk_size)]
+            remaining = list(chunk)
+            attempt = 0
+            partial_failures: list[tuple[int, str]] = []
+            while remaining and attempt < max(1, max_retries):
+                attempt += 1
+                results = await _ingest_chunk(
+                    remaining,
+                    concurrency=concurrency,
+                    client=client,
+                )
+                remaining = [ag_id for ag_id, ok, _ in results if not ok]
+                succeeded += sum(1 for _, ok, _ in results if ok)
+                partial_failures = [
+                    (ag_id, error or "unknown error")
+                    for ag_id, ok, error in results
+                    if not ok
+                ]
+
+            failures.extend(partial_failures)
+
+    failed = len(failures)
+    return RepairResult(
+        attempted=attempted,
+        succeeded=succeeded,
+        failed=failed,
+        failures=failures,
+    )
+
+
+__all__ = [
+    "RepairResult",
+    "api_vs_db_spot_check",
+    "collect_missing_variable_ids",
+    "global_health_report",
+    "repair_missing_variables",
+]
+

--- a/src/sidra_va/api_client.py
+++ b/src/sidra_va/api_client.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any, Self
+
+import httpx
+import orjson
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .config import get_settings
+
+
+class SidraApiError(RuntimeError):
+    """Raised when the SIDRA API returns a non-successful response."""
+
+
+class SidraApiClient:
+    """Asynchronous client wrapping SIDRA aggregated-data API endpoints."""
+
+    def __init__(self, *, base_url: str | None = None, timeout: float | None = None) -> None:
+        settings = get_settings()
+        self._client = httpx.AsyncClient(
+            base_url=base_url or settings.sidra_base_url,
+            timeout=timeout or settings.request_timeout,
+            headers={"User-Agent": settings.user_agent},
+        )
+        self._settings = settings
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        await self.close()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    @retry(
+        stop=stop_after_attempt(get_settings().request_retries),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((httpx.TransportError, SidraApiError)),
+        reraise=True,
+    )
+    async def _get_json(self, path: str, params: Mapping[str, Any] | None = None) -> Any:
+        response = await self._client.get(path, params=params)
+        if response.status_code >= 400:
+            message = (
+                f"SIDRA API request failed ({response.status_code}): {response.text[:200]}"
+            )
+            if response.status_code == 429 or response.status_code >= 500:
+                raise SidraApiError(message)
+            raise RuntimeError(message)
+        return orjson.loads(response.content)
+
+    async def fetch_metadata(self, agregado_id: int) -> Any:
+        return await self._get_json(f"/{agregado_id}/metadados")
+
+    async def fetch_periods(self, agregado_id: int) -> Any:
+        return await self._get_json(f"/{agregado_id}/periodos")
+
+    async def fetch_localities(self, agregado_id: int, level: str) -> Any:
+        return await self._get_json(f"/{agregado_id}/localidades/{level}")
+
+    async def fetch_catalog(
+        self,
+        *,
+        subject_id: int | None = None,
+        periodicity: str | None = None,
+        levels: list[str] | None = None,
+    ) -> Any:
+        """Return the agregados catalog grouped by survey/subject."""
+
+        params: dict[str, Any] = {}
+        if subject_id is not None:
+            params["assunto"] = subject_id
+        if periodicity:
+            params["periodicidade"] = periodicity
+        if levels:
+            normalized = [code.upper() for code in levels if code]
+            if normalized:
+                params["nivel"] = "|".join(normalized)
+        return await self._get_json("", params=params or None)
+
+    async def fetch_values(
+        self,
+        agregado_id: int,
+        period: str,
+        variable: int,
+        *,
+        localidades: str | None = None,
+        classificacao: str | None = None,
+        view: str | None = None,
+    ) -> Any:
+        params: dict[str, Any] = {}
+        if localidades:
+            params["localidades"] = localidades
+        if classificacao:
+            params["classificacao"] = classificacao
+        if view:
+            params["view"] = view
+        return await self._get_json(f"/{agregado_id}/periodos/{period}/variaveis/{variable}", params=params)
+
+    async def fetch_latest(self, agregado_id: int, variable: int, **params: Any) -> Any:
+        return await self._get_json(f"/{agregado_id}/variaveis/{variable}", params=params)
+
+
+def fetch_metadata_sync(agregado_id: int) -> Any:
+    """Convenience synchronous helper for quick scripts."""
+
+    async def _runner() -> Any:
+        async with SidraApiClient() as client:
+            return await client.fetch_metadata(agregado_id)
+
+    return asyncio.run(_runner())
+
+
+__all__ = ["SidraApiClient", "SidraApiError", "fetch_metadata_sync"]

--- a/src/sidra_va/base_schema.py
+++ b/src/sidra_va/base_schema.py
@@ -1,0 +1,132 @@
+"""SQLite schema creation helpers for base SIDRA tables."""
+from __future__ import annotations
+
+SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS agregados (
+        id INTEGER PRIMARY KEY,
+        nome TEXT NOT NULL,
+        pesquisa TEXT,
+        assunto TEXT,
+        url TEXT,
+        freq TEXT,
+        periodo_inicio TEXT,
+        periodo_fim TEXT,
+        raw_json BLOB NOT NULL,
+        fetched_at TEXT NOT NULL,
+        municipality_locality_count INTEGER DEFAULT 0,
+        covers_national_municipalities INTEGER DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agregados_levels (
+        agregado_id INTEGER NOT NULL,
+        level_id TEXT NOT NULL,
+        level_name TEXT,
+        level_type TEXT NOT NULL,
+        locality_count INTEGER DEFAULT 0,
+        PRIMARY KEY (agregado_id, level_id, level_type),
+        FOREIGN KEY (agregado_id) REFERENCES agregados(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS variables (
+        id INTEGER PRIMARY KEY,
+        agregado_id INTEGER NOT NULL,
+        nome TEXT NOT NULL,
+        unidade TEXT,
+        sumarizacao TEXT,
+        text_hash TEXT NOT NULL,
+        FOREIGN KEY (agregado_id) REFERENCES agregados(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS classifications (
+        id INTEGER NOT NULL,
+        agregado_id INTEGER NOT NULL,
+        nome TEXT NOT NULL,
+        sumarizacao_status INTEGER,
+        sumarizacao_excecao TEXT,
+        PRIMARY KEY (agregado_id, id),
+        FOREIGN KEY (agregado_id) REFERENCES agregados(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS categories (
+        agregado_id INTEGER NOT NULL,
+        classification_id INTEGER NOT NULL,
+        categoria_id INTEGER NOT NULL,
+        nome TEXT NOT NULL,
+        unidade TEXT,
+        nivel INTEGER,
+        text_hash TEXT NOT NULL,
+        PRIMARY KEY (agregado_id, classification_id, categoria_id),
+        FOREIGN KEY (agregado_id, classification_id) REFERENCES classifications(agregado_id, id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS periods (
+        agregado_id INTEGER NOT NULL,
+        periodo_id TEXT NOT NULL,
+        literals TEXT NOT NULL,
+        modificacao TEXT,
+        PRIMARY KEY (agregado_id, periodo_id),
+        FOREIGN KEY (agregado_id) REFERENCES agregados(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS localities (
+        agregado_id INTEGER NOT NULL,
+        level_id TEXT NOT NULL,
+        locality_id TEXT NOT NULL,
+        nome TEXT NOT NULL,
+        PRIMARY KEY (agregado_id, level_id, locality_id),
+        FOREIGN KEY (agregado_id, level_id) REFERENCES agregados_levels(agregado_id, level_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingestion_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agregado_id INTEGER NOT NULL,
+        stage TEXT NOT NULL,
+        status TEXT NOT NULL,
+        detail TEXT,
+        run_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_variables_agregado ON variables(agregado_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_categories_agregado ON categories(agregado_id, classification_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_localities_agregado ON localities(agregado_id, level_id)
+    """,
+
+)
+
+ADDITIONAL_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("agregados", "municipality_locality_count", "INTEGER DEFAULT 0"),
+    ("agregados", "covers_national_municipalities", "INTEGER DEFAULT 0"),
+    ("agregados_levels", "locality_count", "INTEGER DEFAULT 0"),
+)
+
+
+def _column_exists(connection, table: str, column: str) -> bool:
+    cursor = connection.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def apply_base_schema(connection) -> None:
+    """Execute schema statements on the provided SQLite connection."""
+    cursor = connection.cursor()
+    for stmt in SCHEMA_STATEMENTS:
+        cursor.execute(stmt)
+    for table, column, definition in ADDITIONAL_COLUMNS:
+        if not _column_exists(connection, table, column):
+            cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+    connection.commit()
+
+
+__all__ = ["apply_base_schema"]

--- a/src/sidra_va/bulk_ingest.py
+++ b/src/sidra_va/bulk_ingest.py
@@ -1,0 +1,242 @@
+"""Bulk ingestion helpers that discover and ingest SIDRA agregados."""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from collections.abc import Iterable, Sequence
+from typing import Any, Callable
+
+from .api_client import SidraApiClient
+from .db import ensure_full_schema, sqlite_session
+from .discovery import CatalogEntry, fetch_catalog_entries, filter_catalog_entries
+from .embedding_client import EmbeddingClient
+from .ingest_base import generate_embeddings_for_agregado, ingest_agregado
+
+
+@dataclass(slots=True)
+class BulkIngestionReport:
+    """Outcome of a bulk ingestion run."""
+
+    discovered_ids: list[int] = field(default_factory=list)
+    scheduled_ids: list[int] = field(default_factory=list)
+    skipped_existing: list[int] = field(default_factory=list)
+    ingested_ids: list[int] = field(default_factory=list)
+    failed: list[tuple[int, str]] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serializable summary of the ingestion run."""
+
+        return {
+            "discovered": self.discovered_ids,
+            "scheduled": self.scheduled_ids,
+            "skipped_existing": self.skipped_existing,
+            "ingested": self.ingested_ids,
+            "failed": self.failed,
+        }
+
+
+async def discover_agregados_by_coverage(
+    *,
+    client: SidraApiClient | None = None,
+    require_any_levels: Iterable[str] | None = None,
+    require_all_levels: Iterable[str] | None = None,
+    exclude_levels: Iterable[str] | None = None,
+    subject_contains: str | None = None,
+    survey_contains: str | None = None,
+    limit: int | None = None,
+) -> list[CatalogEntry]:
+    """Return catalog entries matching the requested territorial filters."""
+
+    level_filter: list[str] | None = None
+    if require_any_levels or require_all_levels:
+        combined = [
+            *(code.upper() for code in (require_any_levels or []) if code),
+            *(code.upper() for code in (require_all_levels or []) if code),
+        ]
+        if combined:
+            level_filter = list(dict.fromkeys(combined))
+
+    entries = await fetch_catalog_entries(
+        client=client,
+        levels=level_filter,
+    )
+    filtered = filter_catalog_entries(
+        entries,
+        require_any_levels=require_any_levels,
+        require_all_levels=require_all_levels,
+        exclude_levels=exclude_levels,
+        subject_contains=subject_contains,
+        survey_contains=survey_contains,
+    )
+    if limit is not None and limit >= 0:
+        return filtered[:limit]
+    return filtered
+
+
+async def ingest_by_coverage(
+    *,
+    require_any_levels: Iterable[str] | None = None,
+    require_all_levels: Iterable[str] | None = None,
+    exclude_levels: Iterable[str] | None = None,
+    subject_contains: str | None = None,
+    survey_contains: str | None = None,
+    limit: int | None = None,
+    concurrency: int = 8,
+    skip_existing: bool = True,
+    dry_run: bool = False,
+    client: SidraApiClient | None = None,
+    embedding_client: EmbeddingClient | None = None,
+    progress_callback: Callable[[str], None] | None = None,
+    generate_embeddings: bool = True,
+) -> BulkIngestionReport:
+    """Discover agregados using coverage filters and ingest them."""
+
+    if concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
+
+    ensure_full_schema()
+
+    def _emit(message: str) -> None:
+        if progress_callback is not None:
+            progress_callback(message)
+
+    own_client = False
+    if client is None:
+        client = SidraApiClient()
+        own_client = True
+
+    report = BulkIngestionReport()
+
+    try:
+        candidates = await discover_agregados_by_coverage(
+            client=client,
+            require_any_levels=require_any_levels,
+            require_all_levels=require_all_levels,
+            exclude_levels=exclude_levels,
+            subject_contains=subject_contains,
+            survey_contains=survey_contains,
+            limit=limit,
+        )
+        report.discovered_ids = [entry.id for entry in candidates]
+
+        existing_ids: set[int] = set()
+        if skip_existing:
+            with sqlite_session() as conn:
+                rows = conn.execute("SELECT id FROM agregados")
+                existing_ids = {int(row["id"]) for row in rows}
+
+        to_schedule: list[int] = []
+        for entry in candidates:
+            if entry.id in existing_ids:
+                report.skipped_existing.append(entry.id)
+                continue
+            to_schedule.append(entry.id)
+        report.scheduled_ids = list(to_schedule)
+
+        total_to_schedule = len(to_schedule)
+        if total_to_schedule:
+            _emit(
+                f"Scheduling {total_to_schedule} agregados for ingestion "
+                f"with concurrency={concurrency}"
+            )
+        else:
+            _emit("No new agregados matched the requested filters.")
+
+        if dry_run or not to_schedule:
+            return report
+
+        semaphore = asyncio.Semaphore(concurrency)
+        db_lock = asyncio.Lock() if concurrency > 1 else None
+
+        progress_step = max(1, total_to_schedule // 100) if total_to_schedule > 0 else 1
+        progress_time_budget = 15.0
+        last_progress_at = time.monotonic()
+        completed = 0
+
+        async def _run(agregado_id: int) -> None:
+            nonlocal completed
+            nonlocal last_progress_at
+            async with semaphore:
+                try:
+                    await ingest_agregado(
+                        agregado_id,
+                        client=client,
+                        embedding_client=embedding_client,
+                        generate_embeddings=False,
+                        db_lock=db_lock,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    report.failed.append((agregado_id, str(exc)))
+                    _emit(f"Failed agregado {agregado_id}: {exc}")
+                else:
+                    report.ingested_ids.append(agregado_id)
+                finally:
+                    completed += 1
+                    now = time.monotonic()
+                    should_emit = (
+                        completed <= 10
+                        or completed == total_to_schedule
+                        or completed % progress_step == 0
+                        or (now - last_progress_at) >= progress_time_budget
+                    )
+                    if should_emit:
+                        last_progress_at = now
+                        ingested = len(report.ingested_ids)
+                        failed = len(report.failed)
+                        _emit(
+                            f"Progress {completed}/{total_to_schedule}: "
+                            f"ingested={ingested}, failed={failed}"
+                        )
+
+        await asyncio.gather(*(_run(agregado_id) for agregado_id in to_schedule))
+
+        if generate_embeddings and report.ingested_ids:
+            embed_client = embedding_client or EmbeddingClient()
+            embed_lock = asyncio.Lock() if concurrency > 1 else None
+            embed_semaphore = asyncio.Semaphore(concurrency)
+            embed_total = len(report.ingested_ids)
+            embed_step = max(1, embed_total // 100) if embed_total > 0 else 1
+            embed_last_progress = time.monotonic()
+            completed_embeds = 0
+
+            async def _embed(agregado_id: int) -> None:
+                nonlocal completed_embeds
+                nonlocal embed_last_progress
+                async with embed_semaphore:
+                    try:
+                        await generate_embeddings_for_agregado(
+                            agregado_id,
+                            embedding_client=embed_client,
+                            db_lock=embed_lock,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        report.failed.append((agregado_id, f"embedding: {exc}"))
+                        _emit(f"Embedding failed for {agregado_id}: {exc}")
+                    finally:
+                        completed_embeds += 1
+                        now = time.monotonic()
+                        if (
+                            completed_embeds <= 10
+                            or completed_embeds == embed_total
+                            or completed_embeds % embed_step == 0
+                            or (now - embed_last_progress) >= progress_time_budget
+                        ):
+                            embed_last_progress = now
+                            _emit(
+                                f"Embedding progress {completed_embeds}/{embed_total}"
+                            )
+
+            _emit(
+                f"Generating embeddings for {len(report.ingested_ids)} agregados"
+            )
+            await asyncio.gather(
+                *(_embed(agregado_id) for agregado_id in report.ingested_ids)
+            )
+        return report
+    finally:
+        if own_client:
+            await client.close()
+
+
+__all__ = ["BulkIngestionReport", "discover_agregados_by_coverage", "ingest_by_coverage"]

--- a/src/sidra_va/catalog.py
+++ b/src/sidra_va/catalog.py
@@ -1,0 +1,74 @@
+"""Helpers to enumerate stored agregados and coverage metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .db import sqlite_session
+
+
+@dataclass(frozen=True)
+class AgregadoRecord:
+    """Lightweight snapshot of an agregados entry."""
+
+    id: int
+    nome: str
+    assunto: str | None
+    pesquisa: str | None
+    municipality_locality_count: int
+    covers_national_municipalities: bool
+    fetched_at: str
+
+
+def list_agregados(
+    *,
+    requires_national_munis: bool = False,
+    min_municipality_count: int | None = None,
+    limit: int | None = None,
+    order_by: str = "municipalities",
+) -> list[AgregadoRecord]:
+    """Return agregados rows matching basic coverage filters."""
+
+    valid_order = {
+        "municipalities": "municipality_locality_count DESC, id ASC",
+        "id": "id ASC",
+        "name": "nome COLLATE NOCASE ASC",
+        "fetched": "fetched_at DESC",
+    }
+    if order_by not in valid_order:
+        raise ValueError(f"Unsupported order_by value: {order_by}")
+
+    conditions: list[str] = []
+    params: list[object] = []
+    if requires_national_munis:
+        conditions.append("covers_national_municipalities = 1")
+    if min_municipality_count is not None:
+        conditions.append("municipality_locality_count >= ?")
+        params.append(int(min_municipality_count))
+
+    where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    limit_clause = f"LIMIT {int(limit)}" if limit is not None and limit > 0 else ""
+
+    sql = (
+        "SELECT id, nome, assunto, pesquisa, municipality_locality_count, "
+        "covers_national_municipalities, fetched_at FROM agregados "
+        f"{where_clause} ORDER BY {valid_order[order_by]} {limit_clause}"
+    ).strip()
+
+    rows: list[AgregadoRecord] = []
+    with sqlite_session() as conn:
+        for row in conn.execute(sql, params):
+            rows.append(
+                AgregadoRecord(
+                    id=row["id"],
+                    nome=row["nome"],
+                    assunto=row["assunto"],
+                    pesquisa=row["pesquisa"],
+                    municipality_locality_count=int(row["municipality_locality_count"] or 0),
+                    covers_national_municipalities=bool(row["covers_national_municipalities"]),
+                    fetched_at=row["fetched_at"],
+                )
+            )
+    return rows
+
+
+__all__ = ["AgregadoRecord", "list_agregados"]

--- a/src/sidra_va/cli.py
+++ b/src/sidra_va/cli.py
@@ -3,30 +3,235 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-from typing import Iterable
+import sqlite3
+from dataclasses import asdict
+from typing import Iterable, Sequence
 
-from sidra_database.db import create_connection, ensure_schema
-
+from .api_client import SidraApiClient
+from .bulk_ingest import ingest_by_coverage
+from .catalog import list_agregados
+from .db import create_connection, ensure_full_schema
+from .diagnostics_base import (
+    api_vs_db_spot_check,
+    global_health_report,
+    repair_missing_variables,
+)
 from .embed import embed_vas_for_agregados
+from .embedding_client import EmbeddingClient
+from .ingest_base import ingest_agregado
 from .neighbors import find_neighbors_for_va
-from .schema_migrations import apply_va_schema, get_schema_version
+from .schema_migrations import get_schema_version
 from .search_va import VaResult, VaSearchFilters, search_value_atoms
 from .synonyms import export_synonyms_csv, import_synonyms_csv
 from .value_index import build_va_index_for_agregado, build_va_index_for_all
 
 
-def _ensure_base_schema() -> None:
+def _ensure_va_schema() -> None:
+    ensure_full_schema()
+
+
+def _base_counts(conn) -> tuple[int, int]:
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM agregados").fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0, 0
+    try:
+        with_vars = conn.execute(
+            "SELECT COUNT(DISTINCT agregado_id) FROM variables"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        with_vars = 0
+    return int(total or 0), int(with_vars or 0)
+
+
+def _require_base_metadata(
+    conn,
+    ids: Iterable[int] | None = None,
+) -> tuple[bool, list[int]]:
+    for table in ("agregados", "variables"):
+        try:
+            conn.execute(f"SELECT 1 FROM {table} LIMIT 1")
+        except sqlite3.OperationalError:
+            print(
+                f"Base table '{table}' is missing. Run 'sidra_va.cli ingest' before using sidra-va.",
+            )
+            return False, []
+
+    total, with_vars = _base_counts(conn)
+    if total == 0:
+        print("Database contains no agregados. Run 'sidra_va.cli ingest' first.")
+        return False, []
+    if with_vars == 0:
+        print(
+            "No agregados with variables found. Re-ingest metadata or run 'sidra_va.cli repair-missing'."
+        )
+        return False, []
+
+    zero_ids: list[int] = []
+    if ids:
+        for raw_id in ids:
+            agregado_id = int(raw_id)
+            count = conn.execute(
+                "SELECT COUNT(*) FROM variables WHERE agregado_id = ?",
+                (agregado_id,),
+            ).fetchone()[0]
+            if int(count or 0) == 0:
+                zero_ids.append(agregado_id)
+    return True, zero_ids
+
+
+def _count_rows(conn, table: str) -> int:
+    try:
+        row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0] or 0)
+
+
+async def _ingest_ids(
+    agregado_ids: Sequence[int],
+    *,
+    concurrency: int,
+    generate_embeddings: bool,
+) -> tuple[int, list[tuple[int, str]]]:
+    """Ingest the provided agregados concurrently."""
+
+    if not agregado_ids:
+        return 0, []
+
+    concurrency = max(1, concurrency)
+    semaphore = asyncio.Semaphore(concurrency)
+    db_lock = asyncio.Lock() if concurrency > 1 else None
+    failures: list[tuple[int, str]] = []
+    succeeded = 0
+
+    async with SidraApiClient() as client:
+        embedding_client = EmbeddingClient() if generate_embeddings else None
+
+        async def worker(agregado_id: int) -> None:
+            nonlocal succeeded
+            async with semaphore:
+                try:
+                    await ingest_agregado(
+                        agregado_id,
+                        client=client,
+                        embedding_client=embedding_client,
+                        generate_embeddings=generate_embeddings,
+                        db_lock=db_lock,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    message = str(exc)[:200]
+                    failures.append((agregado_id, message))
+                    print(f"Failed agregado {agregado_id}: {message}")
+                else:
+                    succeeded += 1
+
+        await asyncio.gather(*(worker(agregado_id) for agregado_id in agregado_ids))
+
+    return succeeded, failures
+
+
+def cmd_ingest(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    agregado_ids = [int(value) for value in args.agregado_ids]
+    succeeded, failures = asyncio.run(
+        _ingest_ids(
+            agregado_ids,
+            concurrency=args.concurrent,
+            generate_embeddings=not args.skip_embeddings,
+        )
+    )
+    total = len(agregado_ids)
+    print(f"Ingested {succeeded}/{total} agregados")
+    if failures:
+        print("Failures:")
+        for agregado_id, message in failures[:10]:
+            print(f"  {agregado_id}: {message}")
+        remaining = len(failures) - 10
+        if remaining > 0:
+            print(f"  ... ({remaining} more)")
+
+
+def cmd_ingest_coverage(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    report = asyncio.run(
+        ingest_by_coverage(
+            require_any_levels=args.any_levels,
+            require_all_levels=args.all_levels,
+            exclude_levels=args.exclude_levels,
+            subject_contains=args.subject_contains,
+            survey_contains=args.survey_contains,
+            limit=args.limit,
+            concurrency=max(1, args.concurrent),
+            skip_existing=args.skip_existing,
+            dry_run=args.dry_run,
+            generate_embeddings=not args.skip_embeddings,
+        )
+    )
+    print(json.dumps(report.as_dict(), indent=2, ensure_ascii=False))
+
+
+def cmd_repair_missing(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    result = asyncio.run(
+        repair_missing_variables(
+            chunk_size=max(1, args.chunk),
+            concurrency=max(1, args.concurrent),
+            limit=args.limit,
+            max_retries=max(1, args.retries),
+        )
+    )
+    payload = asdict(result)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def cmd_diagnostics_health(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
     conn = create_connection()
     try:
-        ensure_schema(conn)
-        apply_va_schema(conn)
-        conn.commit()
+        report = global_health_report(conn, sample_limit=max(0, args.health_sample))
     finally:
         conn.close()
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+def cmd_diagnostics_spot_check(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    conn = create_connection()
+    try:
+        report = asyncio.run(
+            api_vs_db_spot_check(
+                conn,
+                sample_size=max(0, args.spot_sample),
+            )
+        )
+    finally:
+        conn.close()
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+def cmd_list_agregados(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    rows = list_agregados(
+        requires_national_munis=args.requires_national_munis,
+        min_municipality_count=args.min_municipalities,
+        limit=args.limit,
+        order_by=args.order,
+    )
+    if args.json:
+        print(json.dumps([asdict(row) for row in rows], indent=2, ensure_ascii=False))
+        return
+    for row in rows:
+        coverage = f"municipalities={row.municipality_locality_count}"
+        national = "national" if row.covers_national_municipalities else "partial"
+        print(
+            f"{row.id}: {row.nome} | assunto={row.assunto} | pesquisa={row.pesquisa} | "
+            f"{coverage} ({national})"
+        )
 
 
 def cmd_db_migrate(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
         version = get_schema_version(conn)
@@ -36,9 +241,10 @@ def cmd_db_migrate(args: argparse.Namespace) -> None:
 
 
 def cmd_db_stats(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        base_total, base_with_vars = _base_counts(conn)
         tables = [
             "value_atoms",
             "value_atom_dims",
@@ -48,25 +254,36 @@ def cmd_db_stats(args: argparse.Namespace) -> None:
         ]
         stats = {}
         for table in tables:
-            count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
-            stats[table] = count
+            stats[table] = _count_rows(conn, table)
     finally:
         conn.close()
+    print(f"agregados_with_variables: {base_with_vars}/{base_total}")
     for table, count in stats.items():
         print(f"{table}: {count}")
 
 
 def cmd_index_build(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
+    conn = create_connection()
+    try:
+        target_ids = args.ids if not args.all else None
+        ready, missing_ids = _require_base_metadata(conn, target_ids)
+    finally:
+        conn.close()
+
+    if not ready:
+        return
+
     if args.all:
         result = asyncio.run(
             build_va_index_for_all(
                 concurrency=args.concurrent,
-                allow_two_dim_combos=args.allow_two_dim_combos,
             )
         )
         if not result:
-            print("No agregados found. Please ingest metadata first.")
+            print(
+                "No agregados with variables available. Ingest metadata before building the VA index."
+            )
         else:
             for ag, count in sorted(result.items()):
                 print(f"agregado {ag}: {count} VAs")
@@ -74,24 +291,50 @@ def cmd_index_build(args: argparse.Namespace) -> None:
 
     if not args.ids:
         raise SystemExit("Provide --ids or --all")
-    for ag_id in args.ids:
+
+    ready_ids = [ag for ag in args.ids if ag not in missing_ids]
+    for missing in missing_ids:
+        print(f"No variables for table {missing}; run 'sidra_va.cli ingest {missing}' first.")
+    if not ready_ids:
+        return
+
+    for ag_id in ready_ids:
         count = asyncio.run(
             build_va_index_for_agregado(
                 ag_id,
-                allow_two_dim_combos=args.allow_two_dim_combos,
             )
         )
         print(f"agregado {ag_id}: {count} VAs")
 
 
 def cmd_index_embed(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
-    ids = args.ids if not args.all else None
-    if ids is None and not args.all:
+    _ensure_va_schema()
+    requested_ids = args.ids if not args.all else None
+    conn = create_connection()
+    try:
+        ready, missing_ids = _require_base_metadata(conn, requested_ids)
+    finally:
+        conn.close()
+
+    if not ready:
+        return
+
+    if requested_ids is None and not args.all:
         raise SystemExit("Provide --ids or --all")
+
+    if requested_ids:
+        valid_ids = [ag for ag in requested_ids if ag not in missing_ids]
+        for missing in missing_ids:
+            print(f"No variables for table {missing}; run 'sidra_va.cli ingest {missing}' first.")
+    else:
+        valid_ids = None
+
+    if valid_ids is not None and not valid_ids:
+        return
+
     stats = asyncio.run(
         embed_vas_for_agregados(
-            ids,
+            valid_ids,
             concurrency=args.concurrent,
             model=args.model,
         )
@@ -103,9 +346,12 @@ def cmd_index_embed(args: argparse.Namespace) -> None:
 
 
 def cmd_index_rebuild_fts(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        ready, _ = _require_base_metadata(conn)
+        if not ready:
+            return
         rows = conn.execute("SELECT va_id, text, table_title, survey, subject FROM value_atoms").fetchall()
         with conn:
             conn.execute("DELETE FROM value_atoms_fts")
@@ -119,9 +365,12 @@ def cmd_index_rebuild_fts(args: argparse.Namespace) -> None:
 
 
 def cmd_synonyms_import(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        ready, _ = _require_base_metadata(conn)
+        if not ready:
+            return
         count = import_synonyms_csv(args.path, conn)
     finally:
         conn.close()
@@ -129,9 +378,12 @@ def cmd_synonyms_import(args: argparse.Namespace) -> None:
 
 
 def cmd_synonyms_export(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        ready, _ = _require_base_metadata(conn)
+        if not ready:
+            return
         count = export_synonyms_csv(args.path, conn)
     finally:
         conn.close()
@@ -174,7 +426,14 @@ def _parse_period(period: str | None) -> tuple[int | None, int | None]:
 
 
 def cmd_search_va(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
+    conn = create_connection()
+    try:
+        ready, _ = _require_base_metadata(conn)
+    finally:
+        conn.close()
+    if not ready:
+        return
     period_start, period_end = _parse_period(args.period)
     filters = VaSearchFilters(
         require_levels=tuple(args.require_level or []),
@@ -187,11 +446,13 @@ def cmd_search_va(args: argparse.Namespace) -> None:
         min_municipalities=args.min_municipalities,
         requires_national_munis=args.requires_national_munis,
     )
+    embedding_client = EmbeddingClient() if args.semantic else None
     results = asyncio.run(
         search_value_atoms(
             args.query,
             filters=filters,
             limit=args.limit,
+            embedding_client=embedding_client,
         )
     )
     if not results:
@@ -201,9 +462,17 @@ def cmd_search_va(args: argparse.Namespace) -> None:
 
 
 def cmd_show_table(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        ready, missing_ids = _require_base_metadata(conn, [args.agregado_id])
+        if not ready:
+            return
+        if missing_ids:
+            print(
+                f"No variables for table {args.agregado_id}; run 'sidra_va.cli ingest {args.agregado_id}' first."
+            )
+            return
         row = conn.execute(
             "SELECT id, nome, pesquisa, assunto, periodo_inicio, periodo_fim FROM agregados WHERE id = ?",
             (args.agregado_id,),
@@ -247,9 +516,12 @@ def cmd_show_table(args: argparse.Namespace) -> None:
 
 
 def cmd_show_va(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
     conn = create_connection()
     try:
+        ready, _ = _require_base_metadata(conn)
+        if not ready:
+            return
         row = conn.execute(
             "SELECT va_id, text FROM value_atoms WHERE va_id = ?",
             (args.va_id,),
@@ -263,7 +535,14 @@ def cmd_show_va(args: argparse.Namespace) -> None:
 
 
 def cmd_link_neighbors(args: argparse.Namespace) -> None:
-    _ensure_base_schema()
+    _ensure_va_schema()
+    conn = create_connection()
+    try:
+        ready, _ = _require_base_metadata(conn)
+    finally:
+        conn.close()
+    if not ready:
+        return
     neighbors = find_neighbors_for_va(
         args.va_id,
         top_k=args.top_k,
@@ -274,6 +553,69 @@ def cmd_link_neighbors(args: argparse.Namespace) -> None:
         return
     for result, score in neighbors:
         print(f"compat={score:.3f} {result.title} [{result.va_id}]")
+
+
+def cmd_diagnostics(args: argparse.Namespace) -> None:
+    _ensure_va_schema()
+    conn = create_connection()
+    try:
+        ready, _ = _require_base_metadata(conn)
+        base_total, base_with_vars = _base_counts(conn)
+        stats = {
+            "value_atoms": _count_rows(conn, "value_atoms"),
+            "value_atom_dims": _count_rows(conn, "value_atom_dims"),
+            "value_atoms_fts": _count_rows(conn, "value_atoms_fts"),
+            "variable_fingerprints": _count_rows(conn, "variable_fingerprints"),
+            "synonyms": _count_rows(conn, "synonyms"),
+        }
+        sample: list[dict[str, object]] = []
+        sample_limit = min(max(args.sample, 0), stats["value_atoms"])
+        if ready and sample_limit > 0:
+            cursor = conn.execute(
+                "SELECT va_id FROM value_atoms ORDER BY RANDOM() LIMIT ?",
+                (sample_limit,),
+            )
+            for row in cursor.fetchall():
+                dims_count = conn.execute(
+                    "SELECT COUNT(*) FROM value_atom_dims WHERE va_id = ?",
+                    (row["va_id"],),
+                ).fetchone()[0]
+                sample.append({"va_id": row["va_id"], "has_dims": bool(dims_count)})
+    finally:
+        conn.close()
+
+    diagnostics = {
+        "base": {
+            "ready": ready,
+            "agregados": base_total,
+            "agregados_with_variables": base_with_vars,
+        },
+        "tables": stats,
+        "fts_consistent": stats["value_atoms"] == stats["value_atoms_fts"],
+        "sample": sample,
+    }
+
+    smoke_query = args.smoke_query
+    smoke_results: list[str] = []
+    smoke_ok = False
+    if ready and stats["value_atoms"] > 0 and smoke_query:
+        results = asyncio.run(
+            search_value_atoms(
+                smoke_query,
+                filters=VaSearchFilters(),
+                limit=max(1, args.smoke_limit),
+            )
+        )
+        smoke_results = [item.va_id for item in results]
+        smoke_ok = bool(results)
+
+    diagnostics["smoke_test"] = {
+        "query": smoke_query,
+        "ok": smoke_ok,
+        "result_ids": smoke_results,
+    }
+
+    print(json.dumps(diagnostics, indent=2, ensure_ascii=False))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -289,13 +631,57 @@ def build_parser() -> argparse.ArgumentParser:
     stats = db_sub.add_parser("stats")
     stats.set_defaults(func=cmd_db_stats)
 
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest one or more agregados")
+    ingest_parser.add_argument("agregado_ids", metavar="AGREGADO", type=int, nargs="+")
+    ingest_parser.add_argument("--concurrent", type=int, default=4)
+    ingest_parser.add_argument("--skip-embeddings", action="store_true")
+    ingest_parser.set_defaults(func=cmd_ingest)
+
+    coverage_parser = subparsers.add_parser(
+        "ingest-coverage",
+        help="Discover agregados by territorial coverage and ingest them",
+    )
+    coverage_parser.add_argument("--any-level", dest="any_levels", nargs="+", default=None)
+    coverage_parser.add_argument("--all-level", dest="all_levels", nargs="+", default=None)
+    coverage_parser.add_argument("--exclude-level", dest="exclude_levels", nargs="+", default=None)
+    coverage_parser.add_argument("--subject-contains", dest="subject_contains", default=None)
+    coverage_parser.add_argument("--survey-contains", dest="survey_contains", default=None)
+    coverage_parser.add_argument("--limit", type=int, default=None)
+    coverage_parser.add_argument("--concurrent", type=int, default=8)
+    coverage_parser.add_argument("--skip-embeddings", action="store_true")
+    coverage_parser.add_argument("--dry-run", action="store_true")
+    coverage_parser.add_argument("--no-skip-existing", dest="skip_existing", action="store_false")
+    coverage_parser.set_defaults(skip_existing=True)
+    coverage_parser.set_defaults(func=cmd_ingest_coverage)
+
+    repair_parser = subparsers.add_parser(
+        "repair-missing",
+        help="Re-ingest agregados that currently have zero variables",
+    )
+    repair_parser.add_argument("--chunk", type=int, default=50)
+    repair_parser.add_argument("--concurrent", type=int, default=6)
+    repair_parser.add_argument("--limit", type=int, default=None)
+    repair_parser.add_argument("--retries", type=int, default=3)
+    repair_parser.set_defaults(func=cmd_repair_missing)
+
+    list_parser = subparsers.add_parser("list", help="List stored agregados")
+    list_parser.add_argument("--requires-national-munis", action="store_true")
+    list_parser.add_argument("--min-municipalities", type=int, default=None)
+    list_parser.add_argument("--limit", type=int, default=None)
+    list_parser.add_argument(
+        "--order",
+        choices=["municipalities", "id", "name", "fetched"],
+        default="municipalities",
+    )
+    list_parser.add_argument("--json", action="store_true")
+    list_parser.set_defaults(func=cmd_list_agregados)
+
     index_parser = subparsers.add_parser("index")
     index_sub = index_parser.add_subparsers(dest="index_command")
 
     build_va = index_sub.add_parser("build-va")
     build_va.add_argument("--ids", nargs="*", type=int)
     build_va.add_argument("--all", action="store_true")
-    build_va.add_argument("--allow-two-dim-combos", action="store_true")
     build_va.add_argument("--concurrent", type=int, default=1)
     build_va.set_defaults(func=cmd_index_build)
 
@@ -331,6 +717,7 @@ def build_parser() -> argparse.ArgumentParser:
     search_va.add_argument("--must-category", action="append")
     search_va.add_argument("--min-municipalities", type=int)
     search_va.add_argument("--requires-national-munis", action="store_true")
+    search_va.add_argument("--semantic", action="store_true", help="Blend semantic scores when embeddings are available")
     search_va.add_argument("--json", action="store_true")
     search_va.set_defaults(func=cmd_search_va)
 
@@ -350,6 +737,28 @@ def build_parser() -> argparse.ArgumentParser:
     neighbors_cmd.add_argument("--top-k", type=int, default=50)
     neighbors_cmd.add_argument("--allow-unit-mismatch", action="store_true")
     neighbors_cmd.set_defaults(func=cmd_link_neighbors)
+
+    diag_parser = subparsers.add_parser("diagnostics", help="Run diagnostics")
+    diag_parser.add_argument("--sample", type=int, default=5)
+    diag_parser.add_argument(
+        "--smoke-query",
+        default="população",
+        help="Query used for the search smoke test (default: população)",
+    )
+    diag_parser.add_argument("--smoke-limit", type=int, default=5)
+    diag_parser.set_defaults(func=cmd_diagnostics)
+    diag_sub = diag_parser.add_subparsers(dest="diagnostics_command")
+
+    diag_health = diag_sub.add_parser("health", help="Report base ingestion health")
+    diag_health.add_argument("--sample", dest="health_sample", type=int, default=50)
+    diag_health.set_defaults(func=cmd_diagnostics_health)
+
+    diag_spot = diag_sub.add_parser(
+        "spot-check",
+        help="Sample agregados missing variables and compare with live API",
+    )
+    diag_spot.add_argument("--sample", dest="spot_sample", type=int, default=10)
+    diag_spot.set_defaults(func=cmd_diagnostics_spot_check)
 
     return parser
 

--- a/src/sidra_va/config.py
+++ b/src/sidra_va/config.py
@@ -1,0 +1,78 @@
+"""Configuration helpers for the sidra_va package."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(frozen=True)
+class VaSettings:
+    """Runtime configuration for sidra_va components."""
+
+    embedding_api_url: str = "http://127.0.0.1:1234/v1/embeddings"
+    embedding_model: str = "text-embedding-qwen3-embedding-0.6b@f16"
+    request_timeout: float = 30.0
+    user_agent: str = "sidra-va/0.1"
+    database_timeout: float = 60.0
+    sidra_base_url: str = "https://servicodados.ibge.gov.br/api/v3/agregados"
+    request_retries: int = 3
+    municipality_national_threshold: int = 0
+
+
+def _lookup_env(name: str) -> str | None:
+    candidates = {name, name.upper(), name.lower()}
+    for candidate in candidates:
+        if candidate in os.environ:
+            return os.environ[candidate]
+    return None
+
+
+def _load_settings() -> VaSettings:
+    defaults = VaSettings()
+    overrides: dict[str, object] = {}
+    prefixes = ("SIDRA_", "SIDRA_VA_")
+    simple_fields = ("embedding_api_url", "embedding_model", "user_agent", "sidra_base_url")
+    for prefix in prefixes:
+        for field in simple_fields:
+            value = _lookup_env(f"{prefix}{field.upper()}")
+            if value:
+                overrides[field] = value
+        timeout_raw = _lookup_env(f"{prefix}REQUEST_TIMEOUT")
+        if timeout_raw:
+            try:
+                overrides["request_timeout"] = float(timeout_raw)
+            except ValueError:
+                pass
+        db_timeout_raw = _lookup_env(f"{prefix}DATABASE_TIMEOUT")
+        if db_timeout_raw:
+            try:
+                overrides["database_timeout"] = float(db_timeout_raw)
+            except ValueError:
+                pass
+        retries_raw = _lookup_env(f"{prefix}REQUEST_RETRIES")
+        if retries_raw:
+            try:
+                overrides["request_retries"] = int(retries_raw)
+            except ValueError:
+                pass
+        muni_thresh_raw = _lookup_env(f"{prefix}MUNICIPALITY_NATIONAL_THRESHOLD")
+        if muni_thresh_raw:
+            try:
+                overrides["municipality_national_threshold"] = int(muni_thresh_raw)
+            except ValueError:
+                pass
+    if overrides:
+        return VaSettings(**{**defaults.__dict__, **overrides})
+    return defaults
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> VaSettings:
+    """Return cached VA configuration settings."""
+
+    return _load_settings()
+
+
+__all__ = ["VaSettings", "get_settings"]
+

--- a/src/sidra_va/db.py
+++ b/src/sidra_va/db.py
@@ -1,0 +1,114 @@
+"""SQLite helpers for sidra_va operations."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from .base_schema import apply_base_schema
+from .config import get_settings
+from .schema_migrations import apply_va_schema
+
+
+def _has_base_tables(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        conn = sqlite3.connect(path)
+    except sqlite3.Error:
+        return False
+    try:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('agregados', 'variables')"
+        )
+        names = {row[0] for row in cursor.fetchall()}
+        return "agregados" in names and "variables" in names
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+def _resolve_database_path(env_value: str | None) -> Path:
+    candidate = Path(env_value).expanduser().resolve() if env_value else None
+    default_path = Path("sidra.db").expanduser().resolve()
+    if candidate is not None:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        if not candidate.exists():
+            if _has_base_tables(default_path):
+                return default_path
+            return candidate
+        if _has_base_tables(candidate):
+            return candidate
+        if _has_base_tables(default_path):
+            return default_path
+        return candidate
+    default_path.parent.mkdir(parents=True, exist_ok=True)
+    return default_path
+
+
+_LAST_ENV_VALUE: str | None = None
+_DATABASE_PATH: Path | None = None
+
+
+def get_database_path() -> Path:
+    """Resolve the SQLite database path used for VA operations."""
+
+    global _DATABASE_PATH, _LAST_ENV_VALUE
+    env_value = os.getenv("SIDRA_VA_DATABASE_PATH")
+    if env_value is None:
+        env_value = os.getenv("SIDRA_DATABASE_PATH")
+    if _DATABASE_PATH is None or env_value != _LAST_ENV_VALUE:
+        _DATABASE_PATH = _resolve_database_path(env_value)
+        _LAST_ENV_VALUE = env_value
+    return _DATABASE_PATH
+
+
+def create_connection() -> sqlite3.Connection:
+    """Create a SQLite connection configured for concurrent reads/writes."""
+
+    settings = get_settings()
+    timeout = max(float(settings.database_timeout), 30.0)
+    connection = sqlite3.connect(
+        get_database_path(),
+        timeout=timeout,
+        check_same_thread=False,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=NORMAL")
+    connection.execute("PRAGMA temp_store=MEMORY")
+    connection.execute("PRAGMA mmap_size=268435456")
+    connection.execute("PRAGMA cache_size=-200000")
+    busy_timeout_ms = max(int(timeout * 1000), 60000)
+    connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+    return connection
+
+
+@contextmanager
+def sqlite_session() -> Iterator[sqlite3.Connection]:
+    connection = create_connection()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def ensure_full_schema(connection: sqlite3.Connection | None = None) -> None:
+    close = False
+    if connection is None:
+        connection = create_connection()
+        close = True
+    try:
+        apply_base_schema(connection)
+        apply_va_schema(connection)
+        connection.commit()
+    finally:
+        if close:
+            connection.close()
+
+
+__all__ = ["create_connection", "ensure_full_schema", "get_database_path", "sqlite_session"]
+

--- a/src/sidra_va/diagnostics_base.py
+++ b/src/sidra_va/diagnostics_base.py
@@ -1,0 +1,228 @@
+"""Diagnostics and repair helpers for SIDRA metadata ingestion."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from .api_client import SidraApiClient
+from .db import sqlite_session
+from .ingest_base import ingest_agregado
+
+
+def _fetch_scalar(conn, query: str, params: Sequence[Any] | None = None) -> int:
+    cursor = conn.execute(query, params or ())
+    row = cursor.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def _get_index_presence(conn, table: str, expected: Iterable[str]) -> dict[str, bool]:
+    cursor = conn.execute(f"PRAGMA index_list({table})")
+    available = {row[1] for row in cursor.fetchall()}
+    return {name: name in available for name in expected}
+
+
+def collect_missing_variable_ids(conn, *, limit: int | None = None) -> list[int]:
+    query = (
+        "SELECT a.id FROM agregados AS a "
+        "LEFT JOIN (SELECT DISTINCT agregado_id FROM variables) AS v ON v.agregado_id = a.id "
+        "WHERE v.agregado_id IS NULL ORDER BY a.id"
+    )
+    if limit is not None:
+        query += f" LIMIT {int(limit)}"
+    cursor = conn.execute(query)
+    return [int(row[0]) for row in cursor.fetchall()]
+
+
+def global_health_report(conn, *, sample_limit: int = 50) -> dict[str, Any]:
+    total_agregados = _fetch_scalar(conn, "SELECT COUNT(*) FROM agregados")
+    agregados_with_variables = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM variables"
+    )
+    agregados_with_classifications = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM classifications"
+    )
+    agregados_with_categories = _fetch_scalar(
+        conn, "SELECT COUNT(DISTINCT agregado_id) FROM categories"
+    )
+
+    missing_ids = collect_missing_variable_ids(conn)
+    sample_missing = missing_ids[:sample_limit]
+
+    index_status = {
+        "variables": _get_index_presence(conn, "variables", ["idx_variables_agregado"]),
+        "categories": _get_index_presence(conn, "categories", ["idx_categories_agregado"]),
+        "localities": _get_index_presence(conn, "localities", ["idx_localities_agregado"]),
+        "embeddings": _get_index_presence(conn, "embeddings", ["idx_embeddings_agregado"]),
+    }
+
+    journal_row = conn.execute("PRAGMA journal_mode").fetchone()
+    journal_mode = str(journal_row[0]).upper() if journal_row else "UNKNOWN"
+
+    return {
+        "counts": {
+            "agregados": total_agregados,
+            "agregados_with_variables": agregados_with_variables,
+            "agregados_with_classifications": agregados_with_classifications,
+            "agregados_with_categories": agregados_with_categories,
+            "agregados_missing_variables": len(missing_ids),
+        },
+        "sample_missing_variables": sample_missing,
+        "indexes": index_status,
+        "journal_mode": journal_mode,
+    }
+
+
+async def api_vs_db_spot_check(
+    conn,
+    *,
+    sample_size: int = 10,
+    client: SidraApiClient | None = None,
+) -> dict[str, Any]:
+    missing_ids = collect_missing_variable_ids(conn, limit=sample_size)
+    if not missing_ids:
+        return {
+            "sampled": 0,
+            "api_nonempty": 0,
+            "api_empty": 0,
+            "errors": 0,
+            "details": [],
+        }
+
+    own_client = False
+    if client is None:
+        client = SidraApiClient()
+        own_client = True
+
+    results: list[dict[str, Any]] = []
+    try:
+        for agregado_id in missing_ids:
+            try:
+                metadata = await client.fetch_metadata(agregado_id)
+                variaveis = metadata.get("variaveis") if isinstance(metadata, dict) else None
+                if isinstance(variaveis, list):
+                    count = len(variaveis)
+                else:
+                    count = 0
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": count,
+                        "error": None,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                results.append(
+                    {
+                        "agregado_id": agregado_id,
+                        "variables_in_api": None,
+                        "error": str(exc)[:200],
+                    }
+                )
+    finally:
+        if own_client:
+            await client.close()
+
+    api_nonempty = sum(1 for item in results if (item["variables_in_api"] or 0) > 0)
+    api_empty = sum(1 for item in results if item["variables_in_api"] == 0)
+    errors = sum(1 for item in results if item["error"])
+
+    return {
+        "sampled": len(results),
+        "api_nonempty": api_nonempty,
+        "api_empty": api_empty,
+        "errors": errors,
+        "details": results,
+    }
+
+
+@dataclass
+class RepairResult:
+    attempted: int
+    succeeded: int
+    failed: int
+    failures: list[tuple[int, str]]
+
+
+async def _ingest_chunk(
+    ids: Sequence[int],
+    *,
+    concurrency: int,
+    client: SidraApiClient,
+) -> list[tuple[int, bool, str | None]]:
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+    results: list[tuple[int, bool, str | None]] = []
+
+    async def worker(agregado_id: int) -> None:
+        async with semaphore:
+            try:
+                await ingest_agregado(
+                    agregado_id,
+                    client=client,
+                    generate_embeddings=False,
+                )
+                results.append((agregado_id, True, None))
+            except Exception as exc:  # noqa: BLE001
+                results.append((agregado_id, False, str(exc)[:200]))
+
+    await asyncio.gather(*(worker(ag_id) for ag_id in ids))
+    return results
+
+
+async def repair_missing_variables(
+    *,
+    chunk_size: int = 50,
+    concurrency: int = 6,
+    limit: int | None = None,
+    max_retries: int = 3,
+) -> RepairResult:
+    with sqlite_session() as conn:
+        missing_ids = collect_missing_variable_ids(conn, limit=limit)
+
+    if not missing_ids:
+        return RepairResult(attempted=0, succeeded=0, failed=0, failures=[])
+
+    attempted = len(missing_ids)
+    succeeded = 0
+    failures: list[tuple[int, str]] = []
+
+    async with SidraApiClient() as client:
+        for start in range(0, len(missing_ids), max(1, chunk_size)):
+            chunk = missing_ids[start : start + max(1, chunk_size)]
+            remaining = list(chunk)
+            attempt = 0
+            partial_failures: list[tuple[int, str]] = []
+            while remaining and attempt < max(1, max_retries):
+                attempt += 1
+                results = await _ingest_chunk(
+                    remaining,
+                    concurrency=concurrency,
+                    client=client,
+                )
+                remaining = [ag_id for ag_id, ok, _ in results if not ok]
+                succeeded += sum(1 for _, ok, _ in results if ok)
+                partial_failures = [
+                    (ag_id, error or "unknown error")
+                    for ag_id, ok, error in results
+                    if not ok
+                ]
+
+            failures.extend(partial_failures)
+
+    failed = len(failures)
+    return RepairResult(
+        attempted=attempted,
+        succeeded=succeeded,
+        failed=failed,
+        failures=failures,
+    )
+
+
+__all__ = [
+    "RepairResult",
+    "api_vs_db_spot_check",
+    "collect_missing_variable_ids",
+    "global_health_report",
+    "repair_missing_variables",
+]
+

--- a/src/sidra_va/discovery.py
+++ b/src/sidra_va/discovery.py
@@ -1,0 +1,208 @@
+"""Catalog discovery helpers for SIDRA agregados."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from .api_client import SidraApiClient
+
+
+def _normalize_levels(payload: Any) -> dict[str, list[str]]:
+    """Return a mapping of level type -> normalized codes from raw API payload."""
+
+    result: dict[str, list[str]] = {}
+    if isinstance(payload, dict):
+        for key, values in payload.items():
+            values_iter: Iterable[Any]
+            if isinstance(values, str):
+                values_iter = [values]
+            elif isinstance(values, Iterable):
+                values_iter = values
+            else:
+                continue
+            normalized = []
+            for value in values_iter:
+                if isinstance(value, str):
+                    normalized.append(value.upper())
+                elif isinstance(value, Mapping):
+                    code = value.get("codigo") or value.get("nivel") or value.get("id")
+                    if isinstance(code, str):
+                        normalized.append(code.upper())
+            if normalized:
+                result[str(key)] = normalized
+    elif isinstance(payload, list):
+        normalized: list[str] = []
+        for value in payload:
+            if isinstance(value, str):
+                normalized.append(value.upper())
+            elif isinstance(value, Mapping):
+                code = value.get("codigo") or value.get("nivel") or value.get("id")
+                if isinstance(code, str):
+                    normalized.append(code.upper())
+        if normalized:
+            result["codes"] = normalized
+    return result
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """Lightweight representation of an agregados catalog record."""
+
+    id: int
+    nome: str | None
+    pesquisa: str | None
+    pesquisa_id: int | None
+    assunto: str | None
+    assunto_id: int | None
+    periodicidade: Any
+    nivel_territorial: dict[str, list[str]]
+    level_hints: frozenset[str] = frozenset()
+
+    @property
+    def level_codes(self) -> set[str]:
+        """Return all territorial level codes exposed by this agregados."""
+
+        codes: set[str] = set()
+        for values in self.nivel_territorial.values():
+            for value in values:
+                codes.add(value.upper())
+        codes.update(self.level_hints)
+        return codes
+
+    @classmethod
+    def from_api(
+        cls,
+        payload: dict[str, Any],
+        *,
+        pesquisa: dict[str, Any] | None = None,
+        level_hints: Sequence[str] | None = None,
+    ) -> "CatalogEntry":
+        """Build a catalog entry from the API payload."""
+
+        level_payload = payload.get("nivelTerritorial")
+        nome = payload.get("nome") or payload.get("tabela")
+        pesquisa_nome = None
+        pesquisa_id = None
+        assunto_nome = None
+        assunto_id = None
+        periodicidade = None
+
+        if pesquisa is None:
+            pesquisa = {}
+
+        if isinstance(pesquisa, dict):
+            pesquisa_nome = pesquisa.get("pesquisa") or pesquisa.get("nome")
+            pesquisa_id = pesquisa.get("idPesquisa") or pesquisa.get("id")
+            assunto = pesquisa.get("assunto") or {}
+            if isinstance(assunto, dict):
+                assunto_nome = assunto.get("nome")
+                assunto_id = assunto.get("id")
+            else:
+                assunto_nome = pesquisa.get("assunto")
+                assunto_id = pesquisa.get("idAssunto")
+            periodicidade = pesquisa.get("periodicidade")
+
+        return cls(
+            id=int(payload.get("id")),
+            nome=str(nome) if nome is not None else None,
+            pesquisa=str(pesquisa_nome) if pesquisa_nome is not None else None,
+            pesquisa_id=int(pesquisa_id) if isinstance(pesquisa_id, int) else None,
+            assunto=str(assunto_nome) if assunto_nome is not None else None,
+            assunto_id=int(assunto_id) if isinstance(assunto_id, int) else None,
+            periodicidade=periodicidade,
+            nivel_territorial=_normalize_levels(level_payload),
+            level_hints=frozenset(code.upper() for code in level_hints or [] if code),
+        )
+
+
+async def fetch_catalog_entries(
+    *,
+    client: SidraApiClient | None = None,
+    subject_id: int | None = None,
+    periodicity: str | None = None,
+    levels: Sequence[str] | None = None,
+) -> list[CatalogEntry]:
+    """Fetch the agregados catalog and normalize it into CatalogEntry rows."""
+
+    own_client = False
+    if client is None:
+        client = SidraApiClient()
+        own_client = True
+
+    normalized_levels = [code.upper() for code in levels or [] if code]
+
+    try:
+        catalog = await client.fetch_catalog(
+            subject_id=subject_id,
+            periodicity=periodicity,
+            levels=normalized_levels or None,
+        )
+    finally:
+        if own_client:
+            await client.close()
+
+    entries: list[CatalogEntry] = []
+    if not isinstance(catalog, Iterable):
+        return entries
+
+    for survey in catalog:
+        agregados = None
+        if isinstance(survey, dict):
+            agregados = survey.get("agregados")
+        if not isinstance(agregados, Iterable):
+            continue
+        for agregado in agregados:
+            if not isinstance(agregado, dict):
+                continue
+            try:
+                entry = CatalogEntry.from_api(
+                    agregado,
+                    pesquisa=survey,
+                    level_hints=normalized_levels,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+            entries.append(entry)
+    return entries
+
+
+def filter_catalog_entries(
+    entries: Sequence[CatalogEntry],
+    *,
+    require_any_levels: Iterable[str] | None = None,
+    require_all_levels: Iterable[str] | None = None,
+    exclude_levels: Iterable[str] | None = None,
+    subject_contains: str | None = None,
+    survey_contains: str | None = None,
+) -> list[CatalogEntry]:
+    """Filter CatalogEntry items by territorial coverage and optional metadata."""
+
+    any_levels = {code.upper() for code in require_any_levels or ()}
+    all_levels = {code.upper() for code in require_all_levels or ()}
+    excluded = {code.upper() for code in exclude_levels or ()}
+    subject_query = subject_contains.lower() if subject_contains else None
+    survey_query = survey_contains.lower() if survey_contains else None
+
+    filtered: list[CatalogEntry] = []
+    for entry in entries:
+        codes = entry.level_codes
+        if any_levels and not (codes & any_levels):
+            continue
+        if all_levels and not all_levels.issubset(codes):
+            continue
+        if excluded and (codes & excluded):
+            continue
+        if subject_query and (entry.assunto or "").lower().find(subject_query) == -1:
+            continue
+        if survey_query and (entry.pesquisa or "").lower().find(survey_query) == -1:
+            continue
+        filtered.append(entry)
+    return filtered
+
+
+__all__ = [
+    "CatalogEntry",
+    "fetch_catalog_entries",
+    "filter_catalog_entries",
+]

--- a/src/sidra_va/embedding_client.py
+++ b/src/sidra_va/embedding_client.py
@@ -1,0 +1,64 @@
+"""Embedding client used exclusively within sidra_va."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import httpx
+import orjson
+
+from .config import get_settings
+
+
+class EmbeddingClient:
+    """Synchronous HTTP client for embedding generation."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._base_url = base_url or settings.embedding_api_url
+        self._model = model or settings.embedding_model
+        self._timeout = timeout or settings.request_timeout
+        self._headers = {"Content-Type": "application/json", "User-Agent": settings.user_agent}
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def embed_text(self, text: str, *, model: str | None = None) -> Sequence[float]:
+        payload = {
+            "model": model or self._model,
+            "input": text,
+        }
+        response = httpx.post(
+            self._base_url,
+            content=orjson.dumps(payload),
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["data"][0]["embedding"]
+
+    def embed_batch(self, texts: Iterable[str], *, model: str | None = None) -> list[Sequence[float]]:
+        payload = {
+            "model": model or self._model,
+            "input": list(texts),
+        }
+        response = httpx.post(
+            self._base_url,
+            content=orjson.dumps(payload),
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [item["embedding"] for item in data["data"]]
+
+
+__all__ = ["EmbeddingClient"]
+

--- a/src/sidra_va/ingest_base.py
+++ b/src/sidra_va/ingest_base.py
@@ -12,7 +12,7 @@ import orjson
 from .api_client import SidraApiClient
 from .config import get_settings
 from .db import sqlite_session
-from .embedding import EmbeddingClient
+from .embedding_client import EmbeddingClient
 
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 MUNICIPALITY_LEVEL_CODE = "N6"
@@ -290,7 +290,7 @@ async def ingest_agregado(
                         )
                     )
 
-        threshold_setting = max(0, int(settings.municipality_national_threshold))
+        threshold_setting = max(0, int(getattr(settings, "municipality_national_threshold", 0) or 0))
         if threshold_setting == 0:
             covers_national_munis = 1 if municipality_locality_count > 0 else 0
         else:

--- a/src/sidra_va/schema_migrations.py
+++ b/src/sidra_va/schema_migrations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 
-VA_SCHEMA_VERSION = 1
+VA_SCHEMA_VERSION = 2
 
 
 def _ensure_meta_table(connection: sqlite3.Connection) -> None:
@@ -43,6 +43,29 @@ def apply_va_schema(connection: sqlite3.Connection) -> None:
         return
 
     with connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS embeddings (
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              agregado_id INTEGER,
+              text_hash TEXT NOT NULL,
+              model TEXT NOT NULL,
+              dimension INTEGER NOT NULL,
+              vector BLOB NOT NULL,
+              created_at TEXT NOT NULL,
+              PRIMARY KEY (entity_type, entity_id, model)
+            )
+            """
+        )
+
+        connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_embeddings_agregado
+            ON embeddings(agregado_id, model)
+            """
+        )
+
         connection.execute(
             """
             CREATE TABLE IF NOT EXISTS value_atoms (


### PR DESCRIPTION
## Summary
- stop retrying non-retriable SIDRA API responses and make the municipality threshold configurable without requiring a preset value
- keep the embeddings table under the VA schema, tighten ingestion metrics, and harden VA helpers (index build, embeddings, neighbors) for better concurrency and relevance
- add a semantic search flag with structural pre-filtering and standard RRF scoring to cut redundant work and improve ranking quality

## Testing
- pytest tests/test_va_neighbors.py::test_find_neighbors_matches_by_fingerprint
- pytest tests/test_va_search.py

------
https://chatgpt.com/codex/tasks/task_e_68e088c67454832aa7797fca2a4bb7ad