### PR TITLE
Fix search facet semantics and structural scoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,7 +389,7 @@ python -m sidra_search.cli build-links --all
 **Search (lexical only)**
 
 ```bash
-python -m sidra_search.cli search -t "frequência escolar indígena" --limit 10 --explain
+python -m sidra_search.cli search --q 'title~"frequência escolar indígena"' --limit 10 --explain
 ```
 
 **Enable semantic**
@@ -398,7 +398,7 @@ python -m sidra_search.cli search -t "frequência escolar indígena" --limit 10 
 # Start LM Studio (serving /v1/embeddings), then:
 export SIDRA_SEARCH_ENABLE_TITLE_EMBEDDINGS=1
 python -m sidra_search.cli embed-titles --only-missing
-python -m sidra_search.cli search -t "tabela sobre sexo" --semantic --limit 10
+python -m sidra_search.cli search --q 'title~"tabela sobre sexo"' --semantic --limit 10
 ```
 
 ---
@@ -410,6 +410,18 @@ python -m sidra_search.cli search -t "tabela sobre sexo" --semantic --limit 10
 * **Permanent 500s** (e.g., certain tables) will stay in `failed`. Re-runs will not re-ingest them unless the API starts serving them again; they will appear in discovery but be skipped as “existing/failed”.
 * **FTS**: ensure a row is inserted per table (ingestion does this); otherwise lexical title search won’t surface that table.
 * **Embeddings off**: `--semantic` has no effect without embeddings populated.
+* Use `python -m sidra_search.cli --manual` for a quick CLI refresher. When semantic ranking
+  is requested but prerequisites are missing, the CLI now prints diagnostics instead of
+  silently falling back to lexical-only results.
+* **Unified query flag**: prefer `search --q '<expr>'` for all filters. Legacy `--title/--var/--class/--coverage`
+  flags still work for now but only as a translation shim.
+* **Text matching semantics**: `~` checks compare normalized, accent-stripped substrings. Internal
+  prefilters on VAR/CLASS/CAT link keys stay exact for precision; the boolean AST still enforces
+  the user-visible contains logic.
+* **Facet semantics**: `TITLE` literals power lexical/semantic ranking; `SURVEY`/`SUBJECT`
+  literals filter the catalog only. When both VAR and CLASS clauses are present, matches
+  reflect actual `link_var_class` pairs, and `cat~"Class::Category"` requires the exact
+  class/category combination.
 
 ---
 

--- a/src/sidra_search/search/tables.py
+++ b/src/sidra_search/search/tables.py
@@ -1,18 +1,22 @@
-# src/sidra_search/search/tables.py
 from __future__ import annotations
 
 import asyncio
+import math
+import re
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-from ..db.session import create_connection
-from ..db.migrations import apply_search_schema
-from ..search.normalize import normalize_basic
-from ..search.coverage import parse_coverage_expr, extract_levels, eval_coverage
-from ..search.fuzzy3gram import similar_keys
-from ..search.title_rank import rrf
-from ..net.embedding_client import EmbeddingClient
+from array import array
+
 from ..config import get_settings
+from ..db.migrations import apply_search_schema
+from ..db.session import create_connection
+from ..net.embedding_client import EmbeddingClient
+from ..search.normalize import normalize_basic
+from ..search.title_rank import rrf
+from .where_eval import eval_where
+from .where_expr import WhereNode, iter_contains_literals
+from ..search.fuzzy3gram import similar_keys
 
 
 @dataclass(frozen=True)
@@ -31,23 +35,66 @@ class TableHit:
 
 @dataclass(frozen=True)
 class SearchArgs:
-    title: str | None
-    vars: Tuple[str, ...]
-    classes: Tuple[str, ...]   # "Class" or "Class:Category"
-    coverage: str | None
+    q: str | None
+    where: WhereNode | None
     limit: int
     allow_fuzzy: bool
     var_th: float
     class_th: float
-    semantic: bool    # use embeddings for titles
-    debug_fuzzy: bool  # NEW
+    semantic: bool
+    debug_fuzzy: bool
 
 
-def _split_class(spec: str) -> Tuple[str, Optional[str]]:
-    if ":" in spec:
-        a, b = spec.split(":", 1)
-        return a.strip(), b.strip()
-    return spec.strip(), None
+@dataclass
+class _LiteralQuery:
+    raw: str
+    normalized: str
+    scores: Dict[str, float]
+
+
+@dataclass
+class _TableContext:
+    title: str
+    title_norm: str
+    survey: str
+    survey_norm: str
+    subject: str
+    subject_norm: str
+    vars: List[str]
+    classes: List[str]
+    cats: List[str]
+    cat_any: Set[str]
+    class_cat_map: Dict[str, Set[str]]
+    var_class_map: Dict[str, Set[str]]
+    coverage_counts: Dict[str, int]
+    period_years: Set[int]
+    period_start: str | None
+    period_end: str | None
+    n3: int
+    n6: int
+
+    @property
+    def vars_set(self) -> Set[str]:
+        return set(self.vars)
+
+    @property
+    def classes_set(self) -> Set[str]:
+        return set(self.classes)
+
+    @property
+    def cats_set(self) -> Set[str]:
+        return set(self.cats)
+
+
+@dataclass(frozen=True)
+class _CatRequirements:
+    loose: Set[str]
+    strict: Dict[str, Set[str]]
+    strict_total: int
+    has_any: bool
+
+
+_YEAR_RE = re.compile(r"(\d{4})")
 
 
 def _fts_query(text: str) -> str:
@@ -55,64 +102,455 @@ def _fts_query(text: str) -> str:
     return " ".join(toks)
 
 
-def _union_tables_for_keys(conn, table: str, col: str, keys: Iterable[str]) -> Set[int]:
+def _positive_literals(where: WhereNode | None) -> Dict[str, List[str]]:
+    out: Dict[str, List[str]] = {}
+    if not where:
+        return out
+    for field, polarity, text in iter_contains_literals(where):
+        if not polarity:
+            continue
+        if not text:
+            continue
+        out.setdefault(field.upper(), []).append(text)
+    return out
+
+
+def _build_literal_queries(
+    field: str,
+    literals: Iterable[str],
+    *,
+    allow_fuzzy: bool,
+    threshold: float,
+) -> List[_LiteralQuery]:
+    seen: Set[str] = set()
+    queries: List[_LiteralQuery] = []
+    for lit in literals:
+        norm = normalize_basic(lit)
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        scores: Dict[str, float] = {norm: 1.0}
+        if allow_fuzzy:
+            kind = "var" if field == "VAR" else "class"
+            for key, score in similar_keys(kind, lit, threshold=threshold, top_k=12):
+                scores[key] = max(scores.get(key, 0.0), float(score))
+        queries.append(_LiteralQuery(raw=lit, normalized=norm, scores=scores))
+    return queries
+
+
+def _prefilter_link_exact(
+    conn,
+    table: str,
+    column: str,
+    needles: Iterable[str],
+) -> Set[int]:
+    values = [normalize_basic(n) for n in needles if normalize_basic(n)]
+    if not values:
+        return set()
+    unique = sorted(set(values))
     ids: Set[int] = set()
-    keys = [k for k in set(keys) if k]
-    if not keys:
-        return ids
-    for key in keys:
-        rows = conn.execute(f"SELECT DISTINCT table_id FROM {table} WHERE {col} = ?", (key,)).fetchall()
-        ids |= {int(r[0]) for r in rows}
+    chunk = 500
+    for idx in range(0, len(unique), chunk):
+        batch = unique[idx : idx + chunk]
+        placeholders = ",".join("?" for _ in batch)
+        rows = conn.execute(
+            f"SELECT DISTINCT table_id FROM {table} WHERE {column} IN ({placeholders})",
+            batch,
+        ).fetchall()
+        ids.update(int(r[0]) for r in rows)
     return ids
 
 
-def _intersect_groups_union_inside(conn, table: str, col: str, groups: List[Set[str]]) -> Set[int]:
-    """
-    For classes-only queries: for each group (expansions for a requested class),
-    take the union of tables, then intersect across groups.
-    """
-    result: Optional[Set[int]] = None
-    for g in groups:
-        u = _union_tables_for_keys(conn, table, col, g)
-        result = u if result is None else (result & u)
-        if not result:
-            return set()
-    return result or set()
+def _prefilter_agregado_text(
+    conn,
+    column: str,
+    needles: Iterable[str],
+) -> Set[int]:
+    # TODO: cache normalized aggregates or add an index if catalog size makes this scan hot.
+    normalized = [normalize_basic(n) for n in needles if normalize_basic(n)]
+    if not normalized:
+        return set()
+    rows = conn.execute(f"SELECT id, {column} FROM agregados").fetchall()
+    ids: Set[int] = set()
+    for row in rows:
+        value = normalize_basic(str(row[column] or ""))
+        if any(needle in value for needle in normalized):
+            ids.add(int(row["id"]))
+    return ids
 
 
-def _tables_for_class_cat_multi(conn, groups_and_cat: List[Tuple[Set[str], str]]) -> Set[int]:
-    """
-    Intersect across pairs. For each pair, we accept any class_key from the group's expansions,
-    but the category_key is strict (per plan).
-    """
-    result: Optional[Set[int]] = None
-    for class_keys, cat_key in groups_and_cat:
-        if not class_keys or not cat_key:
-            return set()
-        u: Set[int] = set()
-        for ck in class_keys:
-            rows = conn.execute(
-                "SELECT DISTINCT table_id FROM link_cat WHERE class_key=? AND cat_key=?",
-                (ck, cat_key),
-            ).fetchall()
-            u |= {int(r[0]) for r in rows}
-        result = u if result is None else (result & u)
-        if not result:
-            return set()
-    return result or set()
+def _prefilter_title_fts(conn, literals: Iterable[str]) -> Set[int]:
+    settings = get_settings()
+    if not settings.enable_titles_fts:
+        return set()
+    terms: List[str] = []
+    for lit in literals:
+        norm = normalize_basic(lit)
+        if not norm:
+            continue
+        tokens = [t for t in norm.split() if t]
+        if not tokens:
+            continue
+        if len(tokens) == 1:
+            terms.append(tokens[0])
+        else:
+            terms.append(" ".join(tokens))
+    if not terms:
+        return set()
+    query = " OR ".join(f'"{t}"' if " " in t else t for t in terms)
+    rows = conn.execute(
+        "SELECT DISTINCT table_id FROM table_titles_fts WHERE table_titles_fts MATCH ?",
+        (query,),
+    ).fetchall()
+    return {int(r[0]) for r in rows}
 
 
-def _select_in(conn, sql_prefix: str, items: Sequence[str], *prefix_params) -> List[tuple]:
-    """
-    Helper to run `sql_prefix ... IN (?)` safely with dynamic placeholders.
-    Returns rows as tuples.
-    """
-    if not items:
-        return []
-    placeholders = ",".join("?" for _ in items)
-    sql = f"{sql_prefix} ({placeholders})"
-    cur = conn.execute(sql, (*prefix_params, *items))
-    return [tuple(r) for r in cur.fetchall()]
+def _extract_years(pid: Any, pord: Any) -> Set[int]:
+    years: Set[int] = set()
+    for value in (pid, pord):
+        if value is None:
+            continue
+        text = str(value)
+        match = _YEAR_RE.search(text)
+        if match:
+            year = int(match.group(1))
+            if 1500 <= year <= 2100:
+                years.add(year)
+    return years
+
+
+def _load_table_context(conn, table_id: int) -> _TableContext:
+    row = conn.execute(
+        """
+        SELECT id, nome, pesquisa, assunto, periodo_inicio, periodo_fim
+        FROM agregados
+        WHERE id=?
+        """,
+        (table_id,),
+    ).fetchone()
+    if not row:
+        empty = _TableContext(
+            title="",
+            title_norm="",
+            survey="",
+            survey_norm="",
+            subject="",
+            subject_norm="",
+            vars=[],
+            classes=[],
+            cats=[],
+            cat_any=set(),
+            class_cat_map={},
+            var_class_map={},
+            coverage_counts={},
+            period_years=set(),
+            period_start=None,
+            period_end=None,
+            n3=0,
+            n6=0,
+        )
+        return empty
+
+    title = str(row["nome"] or "")
+    survey = str(row["pesquisa"] or "")
+    subject = str(row["assunto"] or "")
+
+    var_rows = conn.execute(
+        "SELECT var_key FROM link_var WHERE table_id=?",
+        (table_id,),
+    ).fetchall()
+    vars_list = [normalize_basic(str(r["var_key"] or "")) for r in var_rows if r["var_key"]]
+
+    class_rows = conn.execute(
+        "SELECT class_key FROM link_class WHERE table_id=?",
+        (table_id,),
+    ).fetchall()
+    classes_list = [normalize_basic(str(r["class_key"] or "")) for r in class_rows if r["class_key"]]
+
+    var_class_rows = conn.execute(
+        "SELECT var_key, class_key FROM link_var_class WHERE table_id=?",
+        (table_id,),
+    ).fetchall()
+    var_class_map: Dict[str, Set[str]] = {}
+    for r in var_class_rows:
+        vkey = normalize_basic(str(r["var_key"] or ""))
+        ckey = normalize_basic(str(r["class_key"] or ""))
+        if vkey and ckey:
+            var_class_map.setdefault(vkey, set()).add(ckey)
+
+    cat_rows = conn.execute(
+        "SELECT class_key, cat_key FROM link_cat WHERE table_id=?",
+        (table_id,),
+    ).fetchall()
+    cats_list: List[str] = []
+    cat_any: Set[str] = set()
+    class_cat_map: Dict[str, Set[str]] = {}
+    for r in cat_rows:
+        class_key_raw = str(r["class_key"] or "")
+        cat_key_raw = str(r["cat_key"] or "")
+        class_key = normalize_basic(class_key_raw)
+        cat_key = normalize_basic(cat_key_raw)
+        if not cat_key:
+            continue
+        cat_any.add(cat_key)
+        cats_list.append(cat_key)
+        if class_key:
+            cats_list.append(f"{class_key}::{cat_key}")
+            class_cat_map.setdefault(class_key, set()).add(cat_key)
+
+    cov_rows = conn.execute(
+        "SELECT level_id, locality_count FROM agregados_levels WHERE agregado_id=?",
+        (table_id,),
+    ).fetchall()
+    coverage = {str(r["level_id"]).upper(): int(r["locality_count"] or 0) for r in cov_rows}
+
+    period_rows = conn.execute(
+        "SELECT periodo_id, periodo_ord FROM periods WHERE agregado_id=?",
+        (table_id,),
+    ).fetchall()
+    years: Set[int] = set()
+    for r in period_rows:
+        years |= _extract_years(r["periodo_id"], r["periodo_ord"])
+
+    cats_unique = list(dict.fromkeys(cats_list))
+
+    return _TableContext(
+        title=title,
+        title_norm=normalize_basic(title),
+        survey=survey,
+        survey_norm=normalize_basic(survey),
+        subject=subject,
+        subject_norm=normalize_basic(subject),
+        vars=list(dict.fromkeys(v for v in vars_list if v)),
+        classes=list(dict.fromkeys(c for c in classes_list if c)),
+        cats=cats_unique,
+        cat_any=cat_any,
+        class_cat_map=class_cat_map,
+        var_class_map=var_class_map,
+        coverage_counts=coverage,
+        period_years=years,
+        period_start=row["periodo_inicio"],
+        period_end=row["periodo_fim"],
+        n3=int(coverage.get("N3", 0)),
+        n6=int(coverage.get("N6", 0)),
+    )
+
+
+def _semantic_notice(enabled: bool, msg: str) -> None:
+    if enabled:
+        print(msg)
+
+
+def _parse_cat_requirements(cat_literals: Iterable[str]) -> _CatRequirements:
+    loose: Set[str] = set()
+    strict: Dict[str, Set[str]] = {}
+    has_any = False
+    for lit in cat_literals:
+        raw = lit.strip()
+        if not raw:
+            continue
+        has_any = True
+        if "::" in raw:
+            class_part, cat_part = raw.split("::", 1)
+            class_norm = normalize_basic(class_part)
+            cat_norm = normalize_basic(cat_part)
+            if class_norm and cat_norm:
+                strict.setdefault(class_norm, set()).add(cat_norm)
+        else:
+            cat_norm = normalize_basic(raw)
+            if cat_norm:
+                loose.add(cat_norm)
+    strict_total = sum(len(v) for v in strict.values())
+    return _CatRequirements(loose=loose, strict=strict, strict_total=strict_total, has_any=has_any)
+
+
+def _first_strict_pair(ctx: _TableContext, cat_req: _CatRequirements) -> Optional[str]:
+    for class_key, cats in cat_req.strict.items():
+        have = ctx.class_cat_map.get(class_key, set())
+        for cat in cats:
+            if cat in have:
+                return f"{class_key}::{cat}"
+    return None
+
+
+def _aggregate_var_scores(queries: List[_LiteralQuery]) -> Tuple[Dict[str, float], Set[str]]:
+    scores: Dict[str, float] = {}
+    exact: Set[str] = set()
+    for q in queries:
+        if q.normalized:
+            exact.add(q.normalized)
+        for key, value in q.scores.items():
+            scores[key] = max(scores.get(key, 0.0), float(value))
+    return scores, exact
+
+
+def _build_class_groups(
+    queries: List[_LiteralQuery],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    groups: List[Dict[str, float]] = []
+    exact: List[str] = []
+    for q in queries:
+        if not q.scores:
+            continue
+        groups.append({k: float(v) for k, v in q.scores.items()})
+        exact.append(q.normalized)
+    return groups, exact
+
+
+def _structural_for_table(
+    ctx: _TableContext,
+    *,
+    var_scores: Dict[str, float],
+    var_exact: Set[str],
+    class_groups: List[Dict[str, float]],
+    class_exact: List[str],
+    cat_req: _CatRequirements,
+) -> Optional[Tuple[float, List[str]]]:
+    # Enforce loose category presence
+    for cat in cat_req.loose:
+        if cat not in ctx.cat_any:
+            return None
+
+    # Enforce strict category presence per class
+    for class_key, cats in cat_req.strict.items():
+        have = ctx.class_cat_map.get(class_key, set())
+        if not cats.issubset(have):
+            return None
+
+    has_vars = bool(var_scores)
+    has_classes = bool(class_groups)
+
+    strict_exact = cat_req.strict_total
+
+    if has_vars:
+        present_vars = [vk for vk in ctx.vars if vk in var_scores]
+        if not present_vars:
+            return None
+
+        best_struct = -1.0
+        best_why: List[str] = []
+
+        for vk in present_vars:
+            cls_picks: List[Tuple[str, float, bool]] = []
+            required_classes = set(cat_req.strict.keys())
+            var_allowed_total = ctx.var_class_map.get(vk, set())
+            if required_classes and not required_classes.issubset(var_allowed_total):
+                continue
+            if has_classes:
+                allowed_classes = var_allowed_total
+                if not allowed_classes:
+                    continue
+                ok = True
+                for idx, group in enumerate(class_groups):
+                    if not group:
+                        ok = False
+                        break
+                    candidates = set(group.keys()) & allowed_classes & ctx.classes_set
+                    if not candidates:
+                        ok = False
+                        break
+                    filtered = [
+                        ck
+                        for ck in candidates
+                        if cat_req.strict.get(ck, set()).issubset(ctx.class_cat_map.get(ck, set()))
+                    ]
+                    if not filtered:
+                        ok = False
+                        break
+                    best_ck = max(filtered, key=lambda ck: group.get(ck, 0.0))
+                    cls_picks.append(
+                        (
+                            best_ck,
+                            group.get(best_ck, 0.0),
+                            bool(class_exact[idx]) and best_ck == class_exact[idx],
+                        )
+                    )
+                if not ok:
+                    continue
+
+            var_score = var_scores.get(vk, 0.0)
+            if has_classes and len(class_groups) > 0:
+                avg_class = sum(score for (_ck, score, _ex) in cls_picks) / len(class_groups)
+            else:
+                avg_class = 0.0
+            exact_boost = 0.0
+            if vk in var_exact:
+                exact_boost += 0.10
+            exact_boost += 0.05 * sum(1 for (_ck, _s, ex) in cls_picks if ex)
+            exact_boost += 0.03 * strict_exact
+            struct = 0.55 * var_score + 0.35 * avg_class + exact_boost
+            struct = min(1.0, struct)
+
+            why: List[str] = []
+            label = "=" if vk in var_exact else "≈"
+            why.append(f'var{label}"{vk}"')
+            for ck, _score, ex in cls_picks:
+                clabel = "=" if ex else "≈"
+                why.append(f'class{clabel}"{ck}"')
+            if cls_picks:
+                why.append("var×class")
+            if cat_req.has_any:
+                if cat_req.strict:
+                    strict_hit = _first_strict_pair(ctx, cat_req)
+                    if strict_hit:
+                        why.append(f'cat="{strict_hit}"')
+                why.append("cat")
+
+            if struct > best_struct:
+                best_struct = struct
+                best_why = why
+
+        if best_struct < 0:
+            return None
+        return best_struct, best_why
+
+    if has_classes:
+        picks: List[Tuple[str, float, bool]] = []
+        for idx, group in enumerate(class_groups):
+            if not group:
+                return None
+            candidates = set(group.keys()) & ctx.classes_set
+            if not candidates:
+                return None
+            filtered = [
+                ck
+                for ck in candidates
+                if cat_req.strict.get(ck, set()).issubset(ctx.class_cat_map.get(ck, set()))
+            ]
+            if not filtered:
+                return None
+            best_ck = max(filtered, key=lambda ck: group.get(ck, 0.0))
+            picks.append(
+                (
+                    best_ck,
+                    group.get(best_ck, 0.0),
+                    bool(class_exact[idx]) and best_ck == class_exact[idx],
+                )
+            )
+        avg_class = sum(score for (_ck, score, _ex) in picks) / len(class_groups)
+        exact_boost = 0.05 * sum(1 for (_ck, _s, ex) in picks if ex) + 0.03 * strict_exact
+        struct = 0.35 * avg_class + exact_boost
+        struct = min(1.0, struct)
+        why = [f'class{"=" if ex else "≈"}"{ck}"' for (ck, _s, ex) in picks]
+        if cat_req.has_any:
+            if cat_req.strict:
+                strict_hit = _first_strict_pair(ctx, cat_req)
+                if strict_hit:
+                    why.append(f'cat="{strict_hit}"')
+            why.append("cat")
+        return struct, why
+
+    # No var/class filters; only categories may contribute exact boost
+    exact_boost = 0.03 * strict_exact
+    struct = min(1.0, exact_boost)
+    why: List[str] = []
+    if cat_req.has_any:
+        if cat_req.strict:
+            strict_hit = _first_strict_pair(ctx, cat_req)
+            if strict_hit:
+                why.append(f'cat="{strict_hit}"')
+        why.append("cat")
+    return struct, why
 
 
 async def search_tables(
@@ -124,115 +562,134 @@ async def search_tables(
     try:
         apply_search_schema(conn)
 
-        # ---------- Expand inputs (with scores) ----------
-        # Vars
-        var_cand_score: Dict[str, float] = {}
-        var_exact: Set[str] = set()
-        for v in args.vars or ():
-            ek = normalize_basic(v)
-            if ek:
-                var_cand_score[ek] = max(var_cand_score.get(ek, 0.0), 1.0)  # exact=1.0
-                var_exact.add(ek)
-            if args.allow_fuzzy:
-                for k, s in similar_keys("var", v, threshold=args.var_th, top_k=12):
-                    var_cand_score[k] = max(var_cand_score.get(k, 0.0), float(s))
+        where_ast = args.where
+        positives = _positive_literals(where_ast)
 
-        # Classes (grouped by request)
-        class_groups: List[Dict[str, float]] = []  # one dict per requested class
-        class_exact: List[str] = []                # exact key per group (may be "")
-        class_cat_per_group: List[Optional[str]] = []  # strict category (normalized) or None
-        for spec in args.classes or ():
-            raw_class, raw_cat = _split_class(spec)
-            ck_exact = normalize_basic(raw_class)
-            catk = normalize_basic(raw_cat) if raw_cat else None
+        var_queries = _build_literal_queries(
+            "VAR",
+            positives.get("VAR", []),
+            allow_fuzzy=args.allow_fuzzy,
+            threshold=args.var_th,
+        )
+        class_queries = _build_literal_queries(
+            "CLASS",
+            positives.get("CLASS", []),
+            allow_fuzzy=args.allow_fuzzy,
+            threshold=args.class_th,
+        )
+        cat_literals = positives.get("CAT", [])
 
-            group: Dict[str, float] = {}
-            if ck_exact:
-                group[ck_exact] = 1.0
-            if args.allow_fuzzy and raw_class:
-                for k, s in similar_keys("class", raw_class, threshold=args.class_th, top_k=12):
-                    group[k] = max(group.get(k, 0.0), float(s))
+        var_scores, var_exact = _aggregate_var_scores(var_queries)
+        class_groups, class_exact = _build_class_groups(class_queries)
+        cat_req = _parse_cat_requirements(cat_literals)
 
-            class_groups.append(group)
-            class_exact.append(ck_exact or "")
-            class_cat_per_group.append(catk)
-
-        # ---------- Inspect fuzzy expansions (debug) ----------
         if args.debug_fuzzy:
-            top_vars = sorted(var_cand_score.items(), key=lambda x: x[1], reverse=True)[:12]
-            print("[fuzzy] var:", ", ".join(f"{k}:{s:.2f}" for k,s in top_vars) or "(none)")
-            for i, grp in enumerate(class_groups):
-                top_cls = sorted(grp.items(), key=lambda x: x[1], reverse=True)[:12]
-                print(f"[fuzzy] class[{i}]:", ", ".join(f"{k}:{s:.2f}" for k,s in top_cls) or "(none)")
+            top_vars = [
+                f"{k}:{s:.2f}"
+                for q in var_queries
+                for k, s in sorted(q.scores.items(), key=lambda x: x[1], reverse=True)[:5]
+            ]
+            print("[fuzzy] var:", ", ".join(top_vars) or "(none)")
+            for idx, q in enumerate(class_queries):
+                top_cls = sorted(q.scores.items(), key=lambda x: x[1], reverse=True)[:5]
+                print(
+                    f"[fuzzy] class[{idx}]:",
+                    ", ".join(f"{k}:{s:.2f}" for k, s in top_cls) or "(none)",
+                )
 
-
-        # ---------- Initial candidate tables ----------
         candidates: Optional[Set[int]] = None
+        pre_counts: Dict[str, int] = {}
 
-        # If there are var candidates: union of tables with any var candidate
-        if var_cand_score:
-            ids = _union_tables_for_keys(conn, "link_var", "var_key", var_cand_score.keys())
-            candidates = ids if candidates is None else (candidates & ids)
+        var_hints = {normalize_basic(x) for x in positives.get("VAR", []) if normalize_basic(x)}
+        if var_hints:
+            ids = _prefilter_link_exact(conn, "link_var", "var_key", var_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["var"] = len(ids)
 
-            # Intersect early with class presence if classes were requested
-            if class_groups:
-                groups_sets = [set(g.keys()) for g in class_groups if g]
-                if groups_sets:
-                    cls_ids = _intersect_groups_union_inside(conn, "link_class", "class_key", groups_sets)
-                    candidates = candidates & cls_ids
-                    if not candidates:
-                        return []
+        class_hints = {normalize_basic(x) for x in positives.get("CLASS", []) if normalize_basic(x)}
+        if class_hints:
+            ids = _prefilter_link_exact(conn, "link_class", "class_key", class_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["class"] = len(ids)
 
-                
-        # If classes-only: intersect across groups (union inside)
-        if not var_cand_score and class_groups:
-            groups_sets = [set(g.keys()) for g in class_groups if g]
-            ids = _intersect_groups_union_inside(conn, "link_class", "class_key", groups_sets)
-            candidates = ids if candidates is None else (candidates & ids)
+        cat_hints = set(cat_req.loose)
+        for cats in cat_req.strict.values():
+            cat_hints.update(cats)
+        if cat_hints:
+            ids = _prefilter_link_exact(conn, "link_cat", "cat_key", cat_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["cat"] = len(ids)
 
-        # Class:Category constraints (class fuzzy, category strict)
-        class_cat_groups = [
-            (set(class_groups[i].keys()), catk) for i, catk in enumerate(class_cat_per_group) if catk
-        ]
-        if class_cat_groups:
-            ids = _tables_for_class_cat_multi(conn, class_cat_groups)
-            candidates = ids if candidates is None else (candidates & ids)
+        title_hints = positives.get("TITLE", [])
+        if title_hints:
+            ids = _prefilter_title_fts(conn, title_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["titlefts"] = len(ids)
 
-        # If nothing structural given: all tables
+        survey_hints = positives.get("SURVEY", [])
+        if survey_hints:
+            ids = _prefilter_agregado_text(conn, "pesquisa", survey_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["survey"] = len(ids)
+
+        subject_hints = positives.get("SUBJECT", [])
+        if subject_hints:
+            ids = _prefilter_agregado_text(conn, "assunto", subject_hints)
+            if ids:
+                candidates = set(ids) if candidates is None else candidates & ids
+            pre_counts["subject"] = len(ids)
+
         if candidates is None:
             rows = conn.execute("SELECT id FROM agregados").fetchall()
             candidates = {int(r[0]) for r in rows}
 
+        if args.debug_fuzzy and pre_counts:
+            print(
+                "[pre] candidates≈{} (hints: var={}, class={}, cat={}, titlefts={}, survey={}, subject={})".format(
+                    len(candidates),
+                    pre_counts.get("var", 0),
+                    pre_counts.get("class", 0),
+                    pre_counts.get("cat", 0),
+                    pre_counts.get("titlefts", 0),
+                    pre_counts.get("survey", 0),
+                    pre_counts.get("subject", 0),
+                )
+            )
+
+        ctx_cache: Dict[int, _TableContext] = {}
+
+        def get_ctx(tid: int) -> _TableContext:
+            ctx = ctx_cache.get(tid)
+            if ctx is None:
+                ctx = _load_table_context(conn, tid)
+                ctx_cache[tid] = ctx
+            return ctx
+
+        if where_ast:
+            filtered: Set[int] = set()
+            for tid in candidates:
+                ctx = get_ctx(tid)
+                if eval_where(where_ast, table_ctx=ctx.__dict__):
+                    filtered.add(tid)
+            candidates = filtered
+
         if not candidates:
+            _semantic_notice(args.semantic, "semantic: no tables matched filters; skipping embeddings")
             return []
 
-        # ---------- Coverage filter (post-structural) ----------
-        if args.coverage:
-            try:
-                ast = parse_coverage_expr(args.coverage)
-            except Exception:
-                ast = None
-            if ast:
-                needed = extract_levels(ast)
-                keep: Set[int] = set()
-                for tid in candidates:
-                    rows = conn.execute(
-                        "SELECT level_id, locality_count FROM agregados_levels WHERE agregado_id=?",
-                        (tid,),
-                    ).fetchall()
-                    counts = {str(r["level_id"]).upper(): int(r["locality_count"] or 0) for r in rows}
-                    if eval_coverage(ast, counts):
-                        keep.add(tid)
-                candidates = keep
-                if not candidates:
-                    return []
-
-        # ---------- Title ranking (lexical + semantic) ----------
         lexical_ranks: Dict[int, int] = {}
         semantic_ranks: Dict[int, int] = {}
 
-        if args.title and get_settings().enable_titles_fts:
-            q = _fts_query(args.title)
+        title_literals = positives.get("TITLE", [])
+        title_text = " ".join(dict.fromkeys(title_literals)) if title_literals else ""
+
+        if title_text and get_settings().enable_titles_fts:
+            q = _fts_query(title_text)
             if q:
                 rows = conn.execute(
                     "SELECT table_id FROM table_titles_fts WHERE table_titles_fts MATCH ?",
@@ -241,196 +698,110 @@ async def search_tables(
                 order: List[int] = []
                 seen: Set[int] = set()
                 for r in rows:
-                    t = int(r[0])
-                    if t in candidates and t not in seen:
-                        seen.add(t); order.append(t)
+                    tid = int(r[0])
+                    if tid in candidates and tid not in seen:
+                        seen.add(tid)
+                        order.append(tid)
                     if len(order) >= args.limit * 5:
                         break
                 lexical_ranks = {tid: idx + 1 for idx, tid in enumerate(order)}
 
-        if args.title and args.semantic and get_settings().enable_title_embeddings:
-            emb = embedding_client or EmbeddingClient()
+        semantic_enabled = False
+        semantic_client = embedding_client if embedding_client else None
+        if args.semantic:
+            settings = get_settings()
+            if not title_text.strip():
+                _semantic_notice(args.semantic, "[semantic] no title literals in query; skipping embeddings")
+            elif not settings.enable_title_embeddings:
+                _semantic_notice(args.semantic, "semantic disabled: ENABLE_TITLE_EMBEDDINGS=0")
+            else:
+                model = semantic_client.model if semantic_client else settings.embedding_model
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM embeddings WHERE entity_type='agregado' AND model=?",
+                    (model,),
+                ).fetchone()
+                count = int(row[0]) if row else 0
+                if count == 0:
+                    _semantic_notice(args.semantic, "semantic: no table embeddings found; run `embed-titles`")
+                else:
+                    semantic_enabled = True
+                    if semantic_client is None:
+                        semantic_client = EmbeddingClient(model=model)
+        if title_text and semantic_enabled and semantic_client:
             try:
-                # keyword-only parameter "model", so call with a lambda/partial
-                qvec = await asyncio.to_thread(lambda: emb.embed_text(args.title, model=emb.model))
-            except Exception:
-                qvec = None
-
-            if qvec:
-                ordered = sorted(candidates)
-                placeholders = ",".join("?" for _ in ordered)
-                sql = (
-                    f"SELECT entity_id, dimension, vector "
-                    f"FROM embeddings WHERE entity_type='agregado' AND model=? AND entity_id IN ({placeholders})"
+                qvec = await asyncio.to_thread(
+                    lambda: semantic_client.embed_text(title_text, model=semantic_client.model)
                 )
-                cur = conn.execute(sql, (emb.model, *ordered))
+            except Exception as exc:
+                _semantic_notice(args.semantic, f"semantic: embeddings request failed: {exc} (continuing without)")
+                qvec = None
+            if qvec:
+                ordered = sorted(
+                    candidates,
+                    key=lambda tid: lexical_ranks.get(tid, float("inf")),
+                )
+                cap = max(200, args.limit * 10)
+                ordered = ordered[:cap]
+                if ordered:
+                    placeholders = ",".join("?" for _ in ordered)
+                    sql = (
+                        "SELECT entity_id, dimension, vector "
+                        "FROM embeddings WHERE entity_type='agregado' AND model=? AND entity_id IN ("
+                        + placeholders
+                        + ")"
+                    )
+                    cur = conn.execute(sql, (semantic_client.model, *ordered))
+                    sims: List[Tuple[int, float]] = []
+                    for row in cur.fetchall():
+                        tid = int(row["entity_id"])
+                        blob = row["vector"]
+                        dim = int(row["dimension"])
+                        arr = array("f")
+                        arr.frombytes(blob)
+                        vec = list(arr)
+                        if dim and len(vec) > dim:
+                            vec = vec[:dim]
+                        if not vec:
+                            continue
+                        dot = sum(a * b for a, b in zip(qvec, vec))
+                        norm_q = math.sqrt(sum(a * a for a in qvec))
+                        norm_t = math.sqrt(sum(a * a for a in vec))
+                        sim = 0.0 if norm_q == 0 or norm_t == 0 else dot / (norm_q * norm_t)
+                        if sim > 0:
+                            sims.append((tid, sim))
+                    sims.sort(key=lambda x: x[1], reverse=True)
+                    semantic_ranks = {tid: idx + 1 for idx, (tid, _s) in enumerate(sims[: args.limit * 5])}
 
-                from array import array
-                import math
+        combined_ranks = dict(lexical_ranks)
+        combined_ranks.update(semantic_ranks)
+        rrf_scores = rrf(combined_ranks, k=60.0)
 
-                def to_vec(blob, dim):
-                    arr = array("f"); arr.frombytes(blob); v = list(arr)
-                    return v[:dim] if dim and len(v) > dim else v
-
-                def cosine(a: Sequence[float], b: Sequence[float]) -> float:
-                    if not a or not b or len(a) != len(b): return 0.0
-                    dot = sum(x*y for x,y in zip(a,b))
-                    na = math.sqrt(sum(x*x for x in a))
-                    nb = math.sqrt(sum(x*x for x in b))
-                    return 0.0 if na==0 or nb==0 else dot/(na*nb)
-
-                sims: List[Tuple[int, float]] = []
-                for row in cur.fetchall():
-                    tid = int(row["entity_id"])
-                    vec = to_vec(row["vector"], int(row["dimension"]))
-                    sim = cosine(qvec, vec)
-                    if sim > 0:
-                        sims.append((tid, sim))
-                sims.sort(key=lambda x: x[1], reverse=True)
-                top = [tid for (tid, _s) in sims[: args.limit * 5]]
-                semantic_ranks = {tid: idx + 1 for idx, tid in enumerate(top)}
-
-
-        rrf_scores = rrf({**lexical_ranks, **semantic_ranks}, k=60.0)
-
-        # ---------- Structural scoring with fuzzy pairing ----------
-        # Pre-materialize for speed per table:
-        var_candidates = list(var_cand_score.keys())
-        class_groups_list = [list(g.keys()) for g in class_groups]
-
-        def struct_for_table(tid: int) -> Tuple[float, List[str]]:
-            why: List[str] = []
-
-            # Quickly list var keys present in this table among our candidates
-            present_vars = set(k for (k, ) in _select_in(
-                conn,
-                "SELECT var_key FROM link_var WHERE table_id=? AND var_key IN",
-                var_candidates, tid
-            ))
-
-            # If query has var(s), require at least one present; else classes-only path
-            if var_candidates and not present_vars:
-                return 0.0, []
-
-            # If classes-only, we don't need pairing against a var
-            if not var_candidates and class_groups:
-                score_cls = 0.0
-                for gi, grp in enumerate(class_groups):
-                    present_any = set(k for (k, ) in _select_in(
-                        conn,
-                        "SELECT class_key FROM link_class WHERE table_id=? AND class_key IN",
-                        class_groups_list[gi], tid
-                    ))
-                    if not present_any:
-                        return 0.0, []
-                    # take best cosine in this group
-                    best_ck = max(present_any, key=lambda k: class_groups[gi].get(k, 0.0))
-                    score_cls += class_groups[gi].get(best_ck, 0.0)
-                    exact = class_exact[gi]
-                    if best_ck == exact and exact:
-                        why.append(f'class="{best_ck}"')
-                    else:
-                        why.append(f'class≈"{best_ck}"')
-                s_classes = (score_cls / max(1, len(class_groups)))
-                return (0.35 * s_classes, why)  # small structure score without a var
-
-            # With var(s): choose the BEST variable that satisfies all class groups
-            best_struct = 0.0
-            best_why: List[str] = []
-
-            for vk in present_vars or set(["__no_var__"]):
-                if vk == "__no_var__":  # defensive
-                    continue
-
-                # For each class group, find the best class_key that:
-                #  - pairs with this var (link_var_class)
-                #  - and (if that group has a category) has link_cat(class_key, cat_key)
-                cls_picks: List[Tuple[str, float, bool]] = []  # (ck, score, is_exact)
-                ok_all = True
-                for gi, grp in enumerate(class_groups):
-                    if not grp:
-                        continue
-                    group_keys = list(grp.keys())
-
-                    # category constraint (strict) narrows allowed class keys
-                    if class_cat_per_group[gi]:
-                        allowed = set(k for (k, ) in _select_in(
-                            conn,
-                            "SELECT class_key FROM link_cat WHERE table_id=? AND cat_key=? AND class_key IN",
-                            group_keys, tid, class_cat_per_group[gi]
-                        ))
-                    else:
-                        allowed = set(group_keys)
-
-                    if not allowed:
-                        ok_all = False; break
-
-                    # pairing constraint: only class_keys that pair with this var in this table
-                    paired = set(k for (k, ) in _select_in(
-                        conn,
-                        "SELECT class_key FROM link_var_class WHERE table_id=? AND var_key=? AND class_key IN",
-                        list(allowed), tid, vk
-                    ))
-                    if not paired:
-                        ok_all = False; break
-
-                    # pick the best scoring class key in this group
-                    best_ck = max(paired, key=lambda k: grp.get(k, 0.0))
-                    cls_picks.append((best_ck, grp.get(best_ck, 0.0), best_ck == class_exact[gi]))
-
-                if not ok_all:
-                    continue
-
-                s_var = var_cand_score.get(vk, 0.0)
-                s_classes = (sum(s for (_ck, s, _ex) in cls_picks) / max(1, len(cls_picks))) if cls_picks else 0.0
-                exact_boost = (0.10 if vk in var_exact else 0.0) + 0.05 * sum(1 for (_ck, _s, ex) in cls_picks if ex)
-                struct = 0.55 * s_var + 0.35 * s_classes + exact_boost
-
-                # Build WHY for this candidate
-                why_vk = [f'var{"=" if vk in var_exact else "≈"}"{vk}"']
-                for ck, _s, ex in cls_picks:
-                    why_vk.append(f'class{"=" if ex else "≈"}"{ck}"')
-                if cls_picks:
-                    why_vk.append("var×class")
-
-                if struct > best_struct:
-                    best_struct, best_why = struct, why_vk
-
-            return best_struct, best_why
-
-        # ---------- Assemble hits ----------
         hits: List[TableHit] = []
         for tid in candidates:
-            row = conn.execute(
-                "SELECT id, nome, periodo_inicio, periodo_fim FROM agregados WHERE id=?",
-                (tid,),
-            ).fetchone()
-            if not row:
+            ctx = get_ctx(tid)
+            struct_info = _structural_for_table(
+                ctx,
+                var_scores=var_scores,
+                var_exact=var_exact,
+                class_groups=class_groups,
+                class_exact=class_exact,
+                cat_req=cat_req,
+            )
+            if struct_info is None:
                 continue
+            struct, why = struct_info
 
-            n3r = conn.execute(
-                "SELECT COALESCE(locality_count,0) FROM agregados_levels WHERE agregado_id=? AND level_id='N3'",
-                (tid,),
-            ).fetchone()
-            n6r = conn.execute(
-                "SELECT COALESCE(locality_count,0) FROM agregados_levels WHERE agregado_id=? AND level_id='N6'",
-                (tid,),
-            ).fetchone()
-            n3 = int(n3r[0]) if n3r else 0
-            n6 = int(n6r[0]) if n6r else 0
-
-            struct, why = struct_for_table(tid)
             rrf_score = float(rrf_scores.get(tid, 0.0))
-            final = 0.75 * struct + 0.25 * rrf_score  # per plan
+            final = 0.75 * struct + 0.25 * rrf_score
 
             hits.append(
                 TableHit(
-                    table_id=int(row["id"]),
-                    title=str(row["nome"] or ""),
-                    period_start=row["periodo_inicio"],
-                    period_end=row["periodo_fim"],
-                    n3=n3,
-                    n6=n6,
+                    table_id=tid,
+                    title=ctx.title,
+                    period_start=ctx.period_start,
+                    period_end=ctx.period_end,
+                    n3=ctx.n3,
+                    n6=ctx.n6,
                     why=why,
                     score=final,
                     rrf_score=rrf_score,

--- a/src/sidra_search/search/where_eval.py
+++ b/src/sidra_search/search/where_eval.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .normalize import normalize_basic
+from .where_expr import (
+    WhereNode,
+    _And,
+    _Cmp,
+    _Contains,
+    _Not,
+    _Or,
+    _PeriodCmp,
+    _PeriodRange,
+    _StrLit,
+)
+
+
+def _cmp(op: str, left: int, right: int) -> bool:
+    return {
+        ">=": left >= right,
+        ">": left > right,
+        "<=": left <= right,
+        "<": left < right,
+        "==": left == right,
+        "!=": left != right,
+    }[op]
+
+
+def _years_overlap(years: Sequence[int], start: int, end: int) -> bool:
+    if not years:
+        return False
+    for y in years:
+        if start <= y <= end:
+            return True
+    return False
+
+
+def _field_values(table_ctx: dict[str, Any], field: str) -> list[str]:
+    field = field.upper()
+    if field == "TITLE":
+        return [table_ctx.get("title_norm", "")]
+    if field == "SURVEY":
+        return [table_ctx.get("survey_norm", "")]
+    if field == "SUBJECT":
+        return [table_ctx.get("subject_norm", "")]
+    if field == "VAR":
+        return table_ctx.get("vars", [])
+    if field == "CLASS":
+        return table_ctx.get("classes", [])
+    if field == "CAT":
+        return table_ctx.get("cats", [])
+    return []
+
+
+def _eval_contains_expr(node: WhereNode, haystack: str) -> bool:
+    if isinstance(node, _StrLit):
+        needle = normalize_basic(node.text)
+        if not needle:
+            return True
+        return needle in haystack
+    if isinstance(node, _Not):
+        return not _eval_contains_expr(node.node, haystack)
+    if isinstance(node, _And):
+        return _eval_contains_expr(node.left, haystack) and _eval_contains_expr(node.right, haystack)
+    if isinstance(node, _Or):
+        return _eval_contains_expr(node.left, haystack) or _eval_contains_expr(node.right, haystack)
+    raise TypeError(f"Unexpected node inside contains: {node!r}")
+
+
+def _eval_contains(node: _Contains, table_ctx: dict[str, Any]) -> bool:
+    values = _field_values(table_ctx, node.field)
+    if not values:
+        return False
+    if isinstance(node.needle, _StrLit):
+        needle = normalize_basic(node.needle.text)
+        if not needle:
+            return True
+        return any(needle in v for v in values)
+    for value in values:
+        if _eval_contains_expr(node.needle, value):
+            return True
+    return False
+
+
+def eval_where(node: WhereNode, *, table_ctx: dict[str, Any]) -> bool:
+    def _eval(n: WhereNode) -> bool:
+        if isinstance(n, _Not):
+            return not _eval(n.node)
+        if isinstance(n, _And):
+            return _eval(n.left) and _eval(n.right)
+        if isinstance(n, _Or):
+            return _eval(n.left) or _eval(n.right)
+        if isinstance(n, _Cmp):
+            counts = table_ctx.get("coverage_counts", {})
+            value = int(counts.get(n.ident, 0))
+            return _cmp(n.op, value, n.number)
+        if isinstance(n, _Contains):
+            return _eval_contains(n, table_ctx)
+        if isinstance(n, _PeriodCmp):
+            years = sorted(table_ctx.get("period_years", set()))
+            if not years:
+                return False
+            if n.op == "==":
+                return n.year in years
+            if n.op == ">=":
+                return years[-1] >= n.year
+            if n.op == ">":
+                return years[-1] > n.year
+            if n.op == "<=":
+                return years[0] <= n.year
+            if n.op == "<":
+                return years[0] < n.year
+            raise ValueError(f"Unknown period comparator {n.op}")
+        if isinstance(n, _PeriodRange):
+            years = sorted(table_ctx.get("period_years", set()))
+            return _years_overlap(years, n.start, n.end)
+        if isinstance(n, _StrLit):
+            # Should not reach top-level string literals
+            return bool(normalize_basic(n.text))
+        raise TypeError(f"Unsupported node: {n!r}")
+
+    return _eval(node)
+
+
+__all__ = ["eval_where"]

--- a/src/sidra_search/search/where_expr.py
+++ b/src/sidra_search/search/where_expr.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterator, Tuple
+
+
+@dataclass(frozen=True)
+class _Tok:
+    kind: str
+    value: str
+    pos: int
+
+
+def _tokens(text: str) -> Iterator[_Tok]:
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in "()":
+            yield _Tok("LP" if ch == "(" else "RP", ch, i)
+            i += 1
+            continue
+        if ch == "[":
+            yield _Tok("LBRACK", ch, i)
+            i += 1
+            continue
+        if ch == "]":
+            yield _Tok("RBRACK", ch, i)
+            i += 1
+            continue
+        if ch == "~":
+            yield _Tok("TILDE", ch, i)
+            i += 1
+            continue
+        if ch == "." and i + 1 < n and text[i + 1] == ".":
+            yield _Tok("RANGE", "..", i)
+            i += 2
+            continue
+        if ch == '"':
+            start = i
+            i += 1
+            buf: list[str] = []
+            while i < n:
+                cur = text[i]
+                if cur == "\\":
+                    i += 1
+                    if i >= n:
+                        raise SyntaxError(f"Unterminated string starting at {start}")
+                    esc = text[i]
+                    if esc not in {'"', "\\"}:
+                        buf.append(esc)
+                    else:
+                        buf.append(esc)
+                    i += 1
+                    continue
+                if cur == '"':
+                    i += 1
+                    break
+                buf.append(cur)
+                i += 1
+            else:
+                raise SyntaxError(f"Unterminated string starting at {start}")
+            yield _Tok("STR", "".join(buf), start)
+            continue
+        if i + 1 < n:
+            two = text[i : i + 2]
+            if two in (">=", "<=", "==", "!=", "&&"):
+                yield _Tok("OP" if two != "&&" else "AND", two, i)
+                i += 2
+                continue
+            if two == "||":
+                yield _Tok("OR", two, i)
+                i += 2
+                continue
+        if ch in ("<", ">", "="):
+            yield _Tok("OP", ch, i)
+            i += 1
+            continue
+        if ch.isalpha() or ch == "_":
+            start = i
+            i += 1
+            while i < n and (text[i].isalnum() or text[i] == "_"):
+                i += 1
+            word = text[start:i].upper()
+            if word in {"AND", "OR", "NOT", "IN"}:
+                yield _Tok(word, word, start)
+            else:
+                yield _Tok("ID", word, start)
+            continue
+        if ch.isdigit():
+            start = i
+            i += 1
+            while i < n and text[i].isdigit():
+                i += 1
+            yield _Tok("NUM", text[start:i], start)
+            continue
+        if ch == "!":
+            yield _Tok("NOT", "!", i)
+            i += 1
+            continue
+        raise SyntaxError(f"Unexpected {ch!r} at {i}")
+    yield _Tok("EOF", "", n)
+
+
+@dataclass(frozen=True)
+class _Cmp:
+    op: str
+    ident: str
+    number: int
+
+
+@dataclass(frozen=True)
+class _Not:
+    node: Any
+
+
+@dataclass(frozen=True)
+class _And:
+    left: Any
+    right: Any
+
+
+@dataclass(frozen=True)
+class _Or:
+    left: Any
+    right: Any
+
+
+@dataclass(frozen=True)
+class _StrLit:
+    text: str
+
+
+@dataclass(frozen=True)
+class _Contains:
+    field: str
+    needle: Any
+
+
+@dataclass(frozen=True)
+class _PeriodCmp:
+    op: str
+    year: int
+
+
+@dataclass(frozen=True)
+class _PeriodRange:
+    start: int
+    end: int
+
+
+WhereNode = Any
+
+
+class _Parser:
+    def __init__(self, text: str) -> None:
+        self._it = iter(_tokens(text))
+        self.cur = next(self._it)
+
+    def _eat(self, kind: str) -> _Tok:
+        if self.cur.kind != kind:
+            raise SyntaxError(f"Expected {kind}, got {self.cur.kind} at {self.cur.pos}")
+        tok = self.cur
+        self.cur = next(self._it)
+        return tok
+
+    def parse(self) -> WhereNode:
+        node = self._expr()
+        if self.cur.kind != "EOF":
+            raise SyntaxError(f"Unexpected {self.cur.kind} at {self.cur.pos}")
+        return node
+
+    def _expr(self) -> WhereNode:
+        node = self._and()
+        while self.cur.kind == "OR":
+            self._eat("OR")
+            node = _Or(node, self._and())
+        return node
+
+    def _and(self) -> WhereNode:
+        node = self._unary()
+        while self.cur.kind == "AND":
+            self._eat("AND")
+            node = _And(node, self._unary())
+        return node
+
+    def _unary(self) -> WhereNode:
+        if self.cur.kind == "NOT":
+            self._eat("NOT")
+            return _Not(self._unary())
+        return self._primary()
+
+    def _primary(self) -> WhereNode:
+        if self.cur.kind == "LP":
+            self._eat("LP")
+            node = self._expr()
+            self._eat("RP")
+            return node
+        if self.cur.kind == "ID":
+            return self._field_expr()
+        raise SyntaxError(f"Unexpected {self.cur.kind} at {self.cur.pos}")
+
+    def _field_expr(self) -> WhereNode:
+        ident = self._eat("ID").value
+        if ident == "PERIOD":
+            return self._period_expr()
+        if self.cur.kind == "TILDE":
+            self._eat("TILDE")
+            return _Contains(ident, self._contains_rhs())
+        if self.cur.kind != "OP":
+            return _Cmp(">=", ident, 1)
+        op = self._eat("OP").value
+        if op == "=":
+            op = "=="
+        number = int(self._eat("NUM").value)
+        return _Cmp(op, ident, number)
+
+    def _period_expr(self) -> WhereNode:
+        if self.cur.kind == "ID" and self.cur.value == "IN":
+            self._eat("ID")
+            self._eat("LBRACK")
+            start = int(self._eat("NUM").value)
+            self._eat("RANGE")
+            end = int(self._eat("NUM").value)
+            self._eat("RBRACK")
+            if end < start:
+                raise SyntaxError("period range end < start")
+            return _PeriodRange(start, end)
+        if self.cur.kind != "OP":
+            raise SyntaxError("Expected comparator or IN after PERIOD")
+        op = self._eat("OP").value
+        if op == "=":
+            op = "=="
+        year = int(self._eat("NUM").value)
+        return _PeriodCmp(op, year)
+
+    def _contains_rhs(self) -> WhereNode:
+        if self.cur.kind == "STR":
+            return _StrLit(self._eat("STR").value)
+        if self.cur.kind == "LP":
+            self._eat("LP")
+            node = self._contains_expr()
+            self._eat("RP")
+            return node
+        raise SyntaxError("Expected string or group after ~")
+
+    def _contains_expr(self) -> WhereNode:
+        node = self._contains_and()
+        while self.cur.kind == "OR":
+            self._eat("OR")
+            node = _Or(node, self._contains_and())
+        return node
+
+    def _contains_and(self) -> WhereNode:
+        node = self._contains_unary()
+        while self.cur.kind == "AND":
+            self._eat("AND")
+            node = _And(node, self._contains_unary())
+        return node
+
+    def _contains_unary(self) -> WhereNode:
+        if self.cur.kind == "NOT":
+            self._eat("NOT")
+            return _Not(self._contains_unary())
+        return self._contains_primary()
+
+    def _contains_primary(self) -> WhereNode:
+        if self.cur.kind == "LP":
+            self._eat("LP")
+            node = self._contains_expr()
+            self._eat("RP")
+            return node
+        if self.cur.kind == "STR":
+            return _StrLit(self._eat("STR").value)
+        raise SyntaxError(f"Expected string literal in contains expression at {self.cur.pos}")
+
+
+def parse_where_expr(text: str) -> WhereNode:
+    text = text.strip()
+    if not text:
+        raise SyntaxError("empty query")
+    return _Parser(text).parse()
+
+
+def extract_fields(node: WhereNode) -> set[str]:
+    fields: set[str] = set()
+
+    def _walk(n: WhereNode) -> None:
+        if isinstance(n, _Contains):
+            fields.add(n.field)
+            _walk(n.needle)
+        elif isinstance(n, _Cmp):
+            fields.add(n.ident)
+        elif isinstance(n, (_PeriodCmp, _PeriodRange)):
+            fields.add("PERIOD")
+        elif isinstance(n, _StrLit):
+            return
+        elif isinstance(n, _Not):
+            _walk(n.node)
+        elif isinstance(n, (_And, _Or)):
+            _walk(n.left)
+            _walk(n.right)
+
+    _walk(node)
+    return fields
+
+
+def iter_contains_literals(node: WhereNode, *, positive: bool = True) -> Iterator[Tuple[str, bool, str]]:
+    def _walk(n: WhereNode, polarity: bool) -> Iterator[Tuple[str, bool, str]]:
+        if isinstance(n, _Not):
+            yield from _walk(n.node, not polarity)
+        elif isinstance(n, _And) or isinstance(n, _Or):
+            yield from _walk(n.left, polarity)
+            yield from _walk(n.right, polarity)
+        elif isinstance(n, _Contains):
+            yield from _walk_contains(n.field, n.needle, polarity)
+        elif isinstance(n, (_Cmp, _PeriodCmp, _PeriodRange, _StrLit)):
+            return
+        else:
+            return
+
+    def _walk_contains(field: str, needle: WhereNode, polarity: bool) -> Iterator[Tuple[str, bool, str]]:
+        if isinstance(needle, _StrLit):
+            yield field, polarity, needle.text
+            return
+        if isinstance(needle, _Not):
+            yield from _walk_contains(field, needle.node, not polarity)
+            return
+        if isinstance(needle, (_And, _Or)):
+            yield from _walk_contains(field, needle.left, polarity)
+            yield from _walk_contains(field, needle.right, polarity)
+            return
+
+    yield from _walk(node, positive)
+
+
+__all__ = [
+    "WhereNode",
+    "_Cmp",
+    "_Not",
+    "_And",
+    "_Or",
+    "_StrLit",
+    "_Contains",
+    "_PeriodCmp",
+    "_PeriodRange",
+    "parse_where_expr",
+    "extract_fields",
+    "iter_contains_literals",
+]


### PR DESCRIPTION
## Summary
- enhance the search pipeline to normalize survey/subject catalog prefilters, parse category requirements, enforce real `link_var_class` pairings, cap semantic embedding lookups to title-driven candidates, and tighten link-table prefilters to exact matches with clearer category traces
- refresh the CLI manual to document title-ranking scope, survey/subject filtering, strict category semantics, normalized substring versus exact key prefilters, and align environment variable guidance
- add an agent note describing the preserved facet behaviors, including strict class-category handling
- extend the smoke script with scenarios covering facet isolation, pairing checks, category strictness, semantic diagnostics, and parser-error reporting

## Testing
- python -m compileall src/sidra_search/cli/__init__.py


------
https://chatgpt.com/codex/tasks/task_e_68e87e24e914832a85a1071ab028e38c